### PR TITLE
Modify NetBSD to use struct capable of isolation for namespaces

### DIFF
--- a/external/cddl/osnet/sys/kern/misc.c
+++ b/external/cddl/osnet/sys/kern/misc.c
@@ -71,6 +71,8 @@
 #include <sys/pool.h>
 #include <sys/buf.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 char hw_serial[11] = "0";
 
 struct utsname utsname;
@@ -80,7 +82,7 @@ opensolaris_utsname_init(void *arg)
 {
 
 	strlcpy(utsname.sysname, ostype, sizeof(utsname.sysname));
-	strlcpy(utsname.nodename, hostname, sizeof(utsname.nodename));
+	strlcpy(utsname.nodename, new_ns.hostname, sizeof(utsname.nodename));
 	strlcpy(utsname.release, osrelease, sizeof(utsname.release));
 	strlcpy(utsname.version, version, sizeof(utsname.version));
 	strlcpy(utsname.machine, machine, sizeof(utsname.machine));

--- a/share/man/man4/options.4
+++ b/share/man/man4/options.4
@@ -1673,6 +1673,10 @@ Number of storage slots per file for
 .Xr fileassoc 9 .
 Default is 4.
 .El
+.Ss Namespaces Options
+.Bl -ohang
+.It Cd options NS
+Enables support for Linux like namespaces
 .Ss Networking Options
 .Bl -ohang
 .It Cd options GATEWAY

--- a/sys/arch/amd64/conf/GENERIC.local
+++ b/sys/arch/amd64/conf/GENERIC.local
@@ -1,0 +1,4 @@
+ifndef xpci
+    vio9p*  at virtio?                      # Virtio 9P device
+endif
+options 	UTS_NS

--- a/sys/arch/amd64/conf/GENERIC.local
+++ b/sys/arch/amd64/conf/GENERIC.local
@@ -1,4 +1,3 @@
 ifndef xpci
     vio9p*  at virtio?                      # Virtio 9P device
 endif
-options 	UTS_NS

--- a/sys/arch/amd64/conf/NS
+++ b/sys/arch/amd64/conf/NS
@@ -1,9 +1,9 @@
 # $NetBSD$
 #
-#	NS - Kernel with Linux compatible namespacesAdd commentMore actions
+#	NS - Kernel with Linux compatible namespaces
 #
 #	This kernel is derived from GENERIC.
 
 include	"arch/amd64/conf/GENERIC"
 
-options 	NS	# Linux compatible namespaces
+options		NS	# Linux compatible namespaces

--- a/sys/arch/amd64/conf/NS
+++ b/sys/arch/amd64/conf/NS
@@ -1,0 +1,9 @@
+# $NetBSD$
+#
+#	NS - Kernel with Linux compatible namespacesAdd commentMore actions
+#
+#	This kernel is derived from GENERIC.
+
+include	"arch/amd64/conf/GENERIC"
+
+options 	NS	# Linux compatible namespaces

--- a/sys/arch/amd64/conf/UTS
+++ b/sys/arch/amd64/conf/UTS
@@ -1,0 +1,1244 @@
+# $NetBSD: GENERIC,v 1.616 2025/03/27 12:22:59 riastradh Exp $
+#
+# GENERIC machine description file
+#
+# This machine description file is used to generate the default NetBSD
+# kernel.  The generic kernel does not include all options, subsystems
+# and device drivers, but should be useful for most applications.
+#
+# The machine description file can be customised for your specific
+# machine to reduce the kernel size and improve its performance.
+#
+# For further information on compiling NetBSD kernels, see the config(8)
+# man page.
+#
+# For further information on hardware support for this architecture, see
+# the intro(4) man page.  For further information about kernel options
+# for this architecture, see the options(4) man page.  For an explanation
+# of each device driver in this file see the section 4 man page for the
+# device.
+
+include 	"arch/amd64/conf/std.amd64"
+
+options 	INCLUDE_CONFIG_FILE	# embed config file in kernel binary
+
+#ident		"GENERIC-$Revision: 1.616 $"
+
+maxusers	64		# estimated number of users
+
+# delay between "rebooting ..." message and hardware reset, in milliseconds
+#options 	CPURESET_DELAY=2000
+
+# This option allows you to force a serial console at the specified
+# I/O address.   see console(4) for details.
+#options 	CONSDEVNAME="\"com\"",CONADDR=0x2f8,CONSPEED=57600
+#	you don't want the option below ON iff you are using the
+#	serial console option of the new boot strap code.
+#options 	CONS_OVERRIDE	# Always use above! independent of boot info
+
+# The following options override the memory sizes passed in from the boot
+# block.  Use them *only* if the boot block is unable to determine the correct
+# values.  Note that the BIOS may *correctly* report less than 640k of base
+# memory if the extended BIOS data area is located at the top of base memory
+# (as is the case on most recent systems).
+#options 	REALBASEMEM=639		# size of base memory (in KB)
+#options 	REALEXTMEM=15360	# size of extended memory (in KB)
+
+# The following options limit the overall size of physical memory
+# and/or the maximum address used by the system.
+# Contrary to REALBASEMEM and REALEXTMEM, they still use the BIOS memory map
+# and can deal with holes in the memory layout.
+#options 	PHYSMEM_MAX_SIZE=64	# max size of physical memory (in MB)
+#options 	PHYSMEM_MAX_ADDR=2048	# don't use memory above this (in MB)
+
+# Standard system options
+
+options 	INSECURE	# disable kernel security levels - X needs this
+
+options 	RTC_OFFSET=0	# hardware clock is this many mins. west of GMT
+options 	NTP		# NTP phase/frequency locked loop
+
+options 	KTRACE		# system call tracing via ktrace(1)
+
+options 	CPU_UCODE	# cpu ucode loading support
+
+# Note: SysV IPC parameters could be changed dynamically, see sysctl(8).
+options 	SYSVMSG		# System V-like message queues
+options 	SYSVSEM		# System V-like semaphores
+options 	SYSVSHM		# System V-like memory sharing
+
+options 	MODULAR		# new style module(7) framework
+options 	MODULAR_DEFAULT_AUTOLOAD
+options 	USERCONF	# userconf(4) support
+#options 	PIPE_SOCKETPAIR	# smaller, but slower pipe(2)
+options 	SYSCTL_INCLUDE_DESCR	# Include sysctl descriptions in kernel
+
+# CPU-related options
+options 	USER_LDT	# User-settable LDT, used by Wine
+options 	SVS		# Separate Virtual Space
+options 	PCPU_IDT	# Per CPU IDTs
+
+# GCC Spectre variant 2 mitigation
+makeoptions	SPECTRE_V2_GCC_MITIGATION=1
+options 	SPECTRE_V2_GCC_MITIGATION
+
+# CPU features
+acpicpu*	at cpu?		# ACPI CPU (including frequency scaling)
+coretemp*	at cpu?		# Intel on-die thermal sensor
+est0		at cpu0		# Intel Enhanced SpeedStep (non-ACPI)
+hyperv0 	at cpu0		# Microsoft Hyper-V
+#odcm0		at cpu0		# On-demand clock modulation
+powernow0	at cpu0		# AMD PowerNow! and Cool'n'Quiet (non-ACPI)
+viac7temp*	at cpu?		# VIA C7, Nano and Zhaoxin temperature sensor
+vmt0		at cpu0		# VMware Tools
+
+#Xen PV support for PVH and HVM guests
+options 	XENPVHVM
+options 	XEN
+hypervisor*	at mainbus?		# Xen hypervisor
+xenbus*	 	at hypervisor?		# Xen virtual bus
+xencons*	at hypervisor?		# Xen virtual console
+xennet*  	at xenbus?		# Xen virtual network interface
+xbd*		at xenbus?		# Xen virtual block device
+# experimental: PVH dom0 support
+#options 	DOM0OPS
+#pseudo-device  xenevt
+#pseudo-device  xvif
+#pseudo-device  xbdback
+
+
+# Alternate buffer queue strategies for better responsiveness under high
+# disk I/O load.
+#options 	BUFQ_READPRIO
+options 	BUFQ_PRIOCSCAN
+
+# Diagnostic/debugging support options
+options 	DIAGNOSTIC	# inexpensive kernel consistency checks
+				# XXX to be commented out on release branch
+#options 	DEBUG		# expensive debugging checks/support
+#options 	LOCKDEBUG	# expensive locking checks/support
+
+#
+# Because gcc omits the frame pointer for any -O level, the line below
+# is needed to make backtraces in DDB work.
+#
+makeoptions	COPTS="-O2 -fno-omit-frame-pointer"
+options 	DDB		# in-kernel debugger
+#options 	DDB_COMMANDONENTER="bt"	# execute command when ddb is entered
+#options 	DDB_ONPANIC=1	# see also sysctl(7): `ddb.onpanic'
+options 	DDB_HISTORY_SIZE=512	# enable history editing in DDB
+#options 	KGDB		# remote debugger
+#options 	KGDB_DEVNAME="\"com\"",KGDB_DEVADDR=0x3f8,KGDB_DEVRATE=9600
+makeoptions	DEBUG="-g"	# compile full symbol table for CTF
+options DDB_COMMANDONENTER="trace;show registers"
+#options 	SYSCALL_STATS	# per syscall counts
+#options 	SYSCALL_TIMES	# per syscall times
+#options 	SYSCALL_TIMES_HASCOUNTER	# use 'broken' rdtsc (soekris)
+options 	KDTRACE_HOOKS	# kernel DTrace hooks
+
+# Kernel Undefined Behavior Sanitizer (kUBSan).
+#options 	KUBSAN			# mandatory
+#options 	UBSAN_ALWAYS_FATAL	# optional: panic on all kUBSan reports
+
+# Kernel Address Sanitizer (kASan). You need to disable SVS to use it.
+# The quarantine is optional and can help KASAN find more use-after-frees.
+# Use KASAN_PANIC if you want panics instead of warnings.
+#makeoptions 	KASAN=1		# mandatory
+#options 	KASAN		# mandatory
+#no options 	SVS		# mandatory
+#options 	POOL_QUARANTINE	# optional
+#options 	KASAN_PANIC	# optional
+
+# Kernel Concurrency Sanitizer (kCSan).
+#makeoptions 	KCSAN=1		# mandatory
+#options 	KCSAN		# mandatory
+#options 	KCSAN_PANIC	# optional
+
+# Kernel Memory Sanitizer (kMSan). You need to disable SVS and kernel modules
+# to use it. POOL_NOCACHE is optional and can help KMSAN find uninitialized
+# memory in pool caches. Note that KMSAN requires at least 4GB of RAM.
+#makeoptions 	KMSAN=1		# mandatory
+#options 	KMSAN		# mandatory
+#no options 	SVS		# mandatory
+#no options 	MODULAR		# mandatory
+#no options 	MODULAR_DEFAULT_AUTOLOAD	# mandatory
+#options 	POOL_NOCACHE	# optional
+#options 	KMSAN_PANIC	# optional
+
+# Kernel Code Coverage Driver.
+#makeoptions	KCOV=1
+#options 	KCOV
+
+# Fault Injection Driver.
+#options 	FAULT
+
+# Heartbeat checks
+options 	HEARTBEAT
+options 	HEARTBEAT_MAX_PERIOD_DEFAULT=15
+
+# Compatibility options
+# x86_64 never shipped with a.out binaries; the two options below are
+# only relevant to 32-bit i386 binaries
+#options 	EXEC_AOUT	# required by binaries from before 1.5
+#options 	COMPAT_NOMID	# NetBSD 0.8, 386BSD, and BSDI
+
+# NetBSD backward compatibility. Support goes from COMPAT_15 up until
+# the latest release. Note that really old compat (< COMPAT_16) is only
+# useful for 32-bit i386 binaries.
+include 	"conf/compat_netbsd15.config"
+
+#options 	COMPAT_386BSD_MBRPART # recognize old partition ID
+
+options 	COMPAT_NETBSD32
+options 	EXEC_ELF32
+
+# Wedge support
+options 	DKWEDGE_AUTODISCOVER	# Automatically add dk(4) instances
+options 	DKWEDGE_METHOD_GPT	# Supports GPT partitions as wedges
+#options 	DKWEDGE_METHOD_BSDLABEL	# Support disklabel entries as wedges
+#options 	DKWEDGE_METHOD_MBR	# Support MBR partitions as wedges
+options 	DKWEDGE_METHOD_APPLE	# Support Apple partitions as wedges
+#options 	DKWEDGE_METHOD_RDB	# Support RDB partitions as wedges
+#options 	DKWEDGE_METHOD_TOS	# Support Atari "TOS" partitions as wedges
+
+# File systems
+include "conf/filesystems.config"
+
+# File system options
+# ffs
+options 	FFS_EI		# FFS Endian Independent support
+#options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
+options 	QUOTA		# legacy UFS quotas
+options 	QUOTA2		# new, in-filesystem UFS quotas
+options 	UFS_ACL		# UFS Access Control Lists
+options 	UFS_DIRHASH	# UFS Large Directory Hashing
+options 	UFS_EXTATTR	# Extended attribute support for UFS1
+options 	WAPBL		# File system journaling support
+# lfs
+options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH
+# ext2fs
+# other
+options 	DISKLABEL_EI	# disklabel Endian Independent support
+options 	NFSSERVER	# Network File System server
+
+# Networking options
+#options 	GATEWAY		# packet forwarding
+options 	INET		# IP + ICMP + TCP + UDP
+options 	INET6		# IPV6
+options 	IPSEC		# IP security
+#options 	IPSEC_DEBUG	# debug for IP security
+#options 	MPLS		# MultiProtocol Label Switching (needs mpls)
+#options 	MROUTING	# IP multicast routing
+#options 	PIM		# Protocol Independent Multicast
+options 	NETATALK	# AppleTalk networking protocols
+#options 	CAN		# Controller Area Network protocol
+options 	PPP_BSDCOMP	# BSD-Compress compression support for PPP
+options 	PPP_DEFLATE	# Deflate compression support for PPP
+options 	PPP_FILTER	# Active filter support for PPP (requires bpf)
+#options 	TCP_DEBUG	# Record last TCP_NDEBUG packets with SO_DEBUG
+#options 	TCP_SIGNATURE	# Enable RFC-2385 TCP md5 signatures
+
+#options 	ALTQ		# Manipulate network interfaces' output queues
+#options 	ALTQ_BLUE	# Stochastic Fair Blue
+#options 	ALTQ_CBQ	# Class-Based Queueing
+#options 	ALTQ_CDNR	# Diffserv Traffic Conditioner
+#options 	ALTQ_FIFOQ	# First-In First-Out Queue
+#options 	ALTQ_FLOWVALVE	# RED/flow-valve (red-penalty-box)
+#options 	ALTQ_HFSC	# Hierarchical Fair Service Curve
+#options 	ALTQ_LOCALQ	# Local queueing discipline
+#options 	ALTQ_PRIQ	# Priority Queueing
+#options 	ALTQ_RED	# Random Early Detection
+#options 	ALTQ_RIO	# RED with IN/OUT
+#options 	ALTQ_WFQ	# Weighted Fair Queueing
+
+# These options enable verbose messages for several subsystems.
+# Warning, these may compile large string tables into the kernel!
+#options 	ACPIVERBOSE	# verbose ACPI configuration messages
+#options 	MIIVERBOSE	# verbose PHY autoconfig messages
+options 	PCIVERBOSE	# verbose PCI device autoconfig messages
+#options 	PCI_CONFIG_DUMP	# verbosely dump PCI config space
+#options 	PCMCIAVERBOSE	# verbose PCMCIA configuration messages
+options 	SCSIVERBOSE	# human readable SCSI error messages
+#options 	USBVERBOSE	# verbose USB device autoconfig messages
+options 	HDAUDIOVERBOSE	# human readable HDAUDIO device names
+
+options 	NFS_BOOT_DHCP,NFS_BOOT_BOOTPARAM
+
+#
+# wscons options
+#
+# builtin terminal emulations
+options 	WSEMUL_VT100		# VT100 / VT220 emulation
+#options 	WSEMUL_SUN		# sun terminal emulation
+#options 	WSEMUL_DEFAULT="\"vt100\""  # NB: default is "sun" if enabled
+# different kernel output - see dev/wscons/wsdisplayvar.h
+options 	WSDISPLAY_CUSTOM_OUTPUT	# color customization from wsconsctl(8)
+options 	WS_KERNEL_FG=WSCOL_GREEN
+#options 	WS_KERNEL_BG=WSCOL_BLACK
+# customization of console border color
+options 	WSDISPLAY_CUSTOM_BORDER	# custom border colors via wsconsctl(8)
+# compatibility to other console drivers
+options 	WSDISPLAY_COMPAT_PCVT		# emulate some ioctls
+options 	WSDISPLAY_COMPAT_SYSCONS	# emulate some ioctls
+options 	WSDISPLAY_COMPAT_USL		# wsconscfg VT handling
+options 	WSDISPLAY_COMPAT_RAWKBD		# can get raw scancodes
+# don't attach pckbd as the console if no PS/2 keyboard is found
+options 	PCKBD_CNATTACH_MAY_FAIL
+# see dev/pckbport/wskbdmap_mfii.c for implemented layouts
+#options 	PCKBD_LAYOUT="(KB_DE | KB_NODEAD)"
+# allocate a number of virtual screens at autoconfiguration time
+#options 	WSDISPLAY_DEFAULTSCREENS=4
+# use a large software cursor that doesn't blink
+options 	PCDISPLAY_SOFTCURSOR
+# modify the screen type of the console; defaults to "80x25"
+#options 	VGA_CONSOLE_SCREENTYPE="\"80x24\""
+# work around a hardware bug that loaded fonts don't work; found on ATI cards
+#options 	VGA_CONSOLE_ATI_BROKEN_FONTSEL
+# console scrolling support.
+options 	WSDISPLAY_SCROLLSUPPORT
+# enable VGA raster mode capable of displaying multilingual text on console
+#options 	VGA_RASTERCONSOLE
+# enable splash screen support; requires genfb or radeonfb
+#options 	SPLASHSCREEN
+
+# Kernel root file system and dump configuration.
+config		netbsd	root on ? type ?
+#config		netbsd	root on sd0a type ffs
+#config		netbsd	root on ? type nfs
+
+#
+# Device configuration
+#
+
+# IPMI support
+ipmi0		at mainbus?
+ipmi_acpi*	at acpi?
+ipmi0		at ipmi_acpi?
+
+# ACPI will be used if present. If not it will fall back to MPBIOS
+acpi0		at mainbus0
+options 	ACPI_SCANPCI		# find PCI roots using ACPI
+options 	MPBIOS			# configure CPUs and APICs using MPBIOS
+options 	MPBIOS_SCANPCI		# MPBIOS configures PCI roots
+#options 	PCI_INTR_FIXUP		# fixup PCI interrupt routing via ACPI
+#options 	PCI_BUS_FIXUP		# fixup PCI bus numbering
+#options 	PCI_ADDR_FIXUP		# fixup PCI I/O addresses
+#options 	ACPI_ACTIVATE_DEV	# If set, activate inactive devices
+options 	VGA_POST		# in-kernel support for VGA POST
+
+# ACPI devices
+acpiacad*	at acpi?		# ACPI AC Adapter
+acpibat*	at acpi?		# ACPI Battery
+acpibut*	at acpi?		# ACPI Button
+acpidalb*	at acpi?		# ACPI Direct Application Launch Button
+acpiec* 	at acpi?		# ACPI Embedded Controller (late)
+acpiecdt*	at acpi?		# ACPI Embedded Controller (early)
+acpifan*	at acpi?		# ACPI Fan
+acpihed*	at acpi?		# ACPI Hardware Error Device
+acpilid*	at acpi?		# ACPI Lid Switch
+#acpipmtr*	at acpi?		# ACPI Power Meter (experimental)
+#acpismbus*	at acpi?		# ACPI SMBus CMI (experimental)
+acpitz* 	at acpi?		# ACPI Thermal Zone
+acpivga*	at acpi?		# ACPI Display Adapter
+acpiout*	at acpivga?		# ACPI Display Output Device
+acpivmgenid*	at acpi?		# ACPI Virtual Machine Generation ID
+acpiwdrt*	at acpi?		# ACPI Watchdog Resource Table
+acpiwmi*	at acpi?		# ACPI WMI Mapper
+apei*		at apeibus?		# ACPI Platform Error Interfaces
+
+# Mainboard devices
+aibs*		at acpi?		# ASUSTeK AI Booster hardware monitor
+asus*		at acpi?		# ASUS hotkeys
+attimer*	at acpi?		# AT Timer
+com0		at acpi?		# Serial communications interface
+com1		at acpi?		# Serial communications interface
+com*		at acpi?		# Serial communications interface
+fdc*		at acpi?		# Floppy disk controller
+fd*		at fdc? drive ?		# the drives themselves
+fujbp*		at acpi?		# Fujitsu Brightness & Pointer
+fujhk*		at acpi?		# Fujitsu Hotkeys
+#hpacel* 	at acpi?		# HP 3D DriveGuard accelerometer
+#hpqlb*		at acpi?		# HP Quick Launch Buttons
+hpet*		at acpihpetbus?		# High Precision Event Timer (table)
+hpet*		at acpinodebus?		# High Precision Event Timer (device)
+joy*		at acpi?		# Joystick/Game port
+lpt0		at acpi?		# Parallel port
+lpt1		at acpi?		# Parallel port
+lpt*		at acpi?		# Parallel port
+mpu*		at acpi?		# Roland MPU-401 MIDI UART
+pckbc*		at acpi?		# PC keyboard controller
+pcppi*		at acpi?		# AT-style speaker sound
+qemufwcfg*	at acpi?		# QEMU Firmware Configuration device
+sdhc*		at acpi?		# SD Host Controller
+sony*		at acpi?		# Sony Notebook Controller
+spic*		at acpi?		# Sony Programmable I/O Controller
+wsmouse*	at spic?		# mouse
+thinkpad*	at acpi?		# IBM/Lenovo Thinkpad hotkeys
+tpm*		at acpi?		# ACPI TPM (Experimental)
+ug*		at acpi?		# Abit uGuru Hardware monitor
+valz*		at acpi?		# Toshiba Dynabook hotkeys
+wb*		at acpi?		# Winbond W83L518D SD/MMC reader
+sdmmc*		at wb?			# SD/MMC bus
+wmidell*	at acpiwmibus?		# Dell WMI mappings
+wmieeepc*	at acpiwmibus?		# Asus Eee PC WMI mappings
+wmihp*		at acpiwmibus?		# HP WMI mappings
+wmimsi* 	at acpiwmibus?		# MSI WMI mappings
+
+# Basic Bus Support
+
+# PCI bus support
+pci*	at mainbus? bus ?
+pci*	at pchb? bus ?
+pci*	at ppb? bus ?
+
+# PCI bridges
+pchb*	at pci? dev ? function ?	# PCI-Host bridges
+options 	AGP_X86
+pcib*	at pci? dev ? function ?	# PCI-ISA bridges
+ppb*	at pci? dev ? function ?	# PCI-PCI bridges
+# XXX 'puc's aren't really bridges, but there's no better place for them here
+puc*	at pci? dev ? function ?	# PCI "universal" comm. cards
+
+amdpcib* at pci? dev ? function ?	# AMD 8111 PCI-ISA w/ HPET
+hpet*	at amdpcib?
+
+pwdog*	at pci? dev ? function ?	# QUANCOM PWDOG1
+
+ichlpcib* at pci? dev ? function ?	# Intel ICH PCI-LPC w/ timecounter,
+					# watchdog, gpio, Speedstep and HPET
+fwhrng* at ichlpcib?		# Intel 82802 FWH Random Number Generator
+#hpet*	at ichlpcib?
+tco*	at tcoichbus?		# TCO watch dog timer
+
+aapic*	at pci? dev ? function ?	# AMD 8131 IO apic
+
+agp*	at pchb?
+
+# ISA bus support
+isa0	at mainbus?
+isa0	at pcib?
+#isa0	at amdpcib?
+isa0	at ichlpcib?
+
+# CardBus bridge support
+cbb*		at pci? dev ? function ?
+cardslot*	at cbb?
+
+# CardBus bus support
+cardbus*	at cardslot?
+pcmcia* 	at cardslot?
+
+# Console Devices
+
+# wscons
+pckbc0		at isa?			# pc keyboard controller
+pckbd*		at pckbc?		# PC keyboard
+pms*		at pckbc?		# PS/2 mouse for wsmouse
+#options 	PMS_DISABLE_POWERHOOK	# Disable PS/2 reset on resume
+options 	PMS_SYNAPTICS_TOUCHPAD	# Enable support for Synaptics Touchpads
+options 	PMS_ELANTECH_TOUCHPAD	# Enable support for Elantech Touchpads
+options 	PMS_ALPS_TOUCHPAD	# Enable support for Alps Touchpads
+vga*		at pci? dev ? function ?
+genfb*		at pci? dev ? function ?
+options 	VCONS_DRAW_INTR
+wsdisplay*	at vga? console ?
+wsdisplay*	at wsemuldisplaydev?
+wskbd*		at pckbd? console ?
+wsmouse*	at pms? mux 0
+wsmouse*	at wsmousedev?
+
+attimer0	at isa?
+pcppi0		at isa?
+sysbeep0	at pcppi?
+
+# DRI legacy drivers
+#i915drm*	at drm?		# Intel i915, i945 DRM driver
+#mach64drm*	at drm?		# mach64 (3D Rage Pro, Rage) DRM driver
+#mgadrm* 	at drm?		# Matrox G[24]00, G[45]50 DRM driver
+#r128drm*	at drm?		# ATI Rage 128 DRM driver
+#radeondrm*	at drm?		# ATI Radeon DRM driver
+#savagedrm*	at drm?		# S3 Savage DRM driver
+#sisdrm* 	at drm?		# SiS DRM driver
+#tdfxdrm*	at drm?		# 3dfx (voodoo) DRM driver
+
+# DRMKMS drivers
+i915drmkms*	at pci? dev ? function ?
+intelfb*	at intelfbbus?
+
+radeon* 	at pci? dev ? function ?
+radeondrmkmsfb* at radeonfbbus?
+
+#amdgpu*	at pci? dev ? function ?
+#amdgpufb*	at amdgpufbbus?
+
+nouveau*	at pci? dev ? function ?
+nouveaufb*	at nouveaufbbus?
+
+# DRMUMS drivers -- make them loadable, but not statically linked in
+options 	DRM_LEGACY
+#viadrmums*	at drm?
+
+#options 	DRM_MAX_RESOLUTION_HORIZONTAL=1920	# Limit DRM size in horizontal dimension
+#options 	DRM_MAX_RESOLUTION_VERTICAL=1080	# Limit DRM size in vertical dimension
+
+# Cryptographic Devices
+
+# PCI cryptographic devices
+amdccp*	at pci? dev ? function ?	# AMD Cryptographic Coprocessor
+hifn*	at pci? dev ? function ?	# Hifn 7755/7811/795x
+#qat*	at pci? dev ? function ?	# Intel QuickAssist
+ubsec*	at pci? dev ? function ?	# Broadcom 5501/5601/580x/582x
+
+# Trusted Platform Module
+tpm*	at isa? iomem 0xfed40000 irq 7
+
+# Serial Devices
+
+# PCI serial interfaces
+com*	at puc? port ?			# 16x50s on "universal" comm boards
+cy*	at pci? dev ? function ?	# Cyclades Cyclom-Y serial boards
+cz*	at pci? dev ? function ?	# Cyclades-Z multi-port serial boards
+
+# PCMCIA serial interfaces
+com*	at pcmcia? function ?		# Modems and serial cards
+
+pcmcom* at pcmcia? function ?		# PCMCIA multi-port serial cards
+com*	at pcmcom? slave ?		# ...and the slave devices
+
+# CardBus serial interfaces
+com*	at cardbus? function ?	# Modems and serial cards
+
+# ISA serial interfaces
+#options 	COM_HAYESP		# adds Hayes ESP serial board support
+com0	at isa? port 0x3f8 irq 4	# Standard PC serial ports
+com1	at isa? port 0x2f8 irq 3
+
+# Parallel Printer Interfaces
+
+# PCI parallel printer interfaces
+lpt*	at puc? port ?			# || ports on "universal" comm boards
+
+# ISA parallel printer interfaces
+lpt0	at isa? port 0x378 irq 7	# standard PC parallel ports
+lpt1	at isa? port 0x278
+
+# Hardware monitors
+
+amdnb_misc* at pci?			# AMD NB Misc Configuration
+amdtemp* at amdnb_misc?  		# AMD CPU Temperature sensors
+
+amdsmn* at pci?				# AMD SMN Configuration
+amdzentemp* at amdsmnbus?		# AMD Ryzen Family 17h CPU temp sensors
+
+# Winbond LPC Super I/O
+#wbsio*	at isa? port 0x2e
+#wbsio*	at isa? port 0x4e
+
+# IBM Hawk Integrated Systems Management Processor
+#ibmhawk0	at iic? addr 0x37
+
+# LM7[89] and compatible hardware monitors
+# Use flags to select temp sensor type (see lm(4) man page for details)
+#lm0	at isa?	port 0x290 flags 0x0	# other common ports: 0x280, 0x310
+#lm*	at wbsio?
+
+# SMSC LPC47B397 hardware monitor functions
+#smsc0	at isa? port 0x02e
+
+# SMSC LPC47M192 hardware monitor
+#smscmon*	at iic? addr 0x2c
+#smscmon*	at iic? addr 0x2d	# (alternate address)
+
+# AMD 768 and 8111 power/ACPI controllers
+amdpm*	at pci? dev ? function ?	# RNG and SMBus 1.0 interface
+#iic*	at amdpm?			# sensors below are on this bus
+
+# NVIDIA nForce2/3/4 SMBus controller
+nfsmbc* at pci? dev ? function ?
+nfsmb*	at nfsmbc?
+iic*	at nfsmb?
+
+# Intel PIIX4 power management controllers
+piixpm* at pci? dev ? function ?	# PIIX4 compatible PM controller
+iic*	at piixpm?			# SMBus on PIIX4
+
+# Intel ICH SMBus controller
+ichsmb* at pci? dev ? function ?
+iic*	at ichsmb?
+
+# Intel S1200,C2000 (non-pch) SMBus controller
+ismt* at pci? dev ? function ?
+iic*	at ismt?
+
+# DesignWare I2C controller as found in some Intel PCH and AMD FCH devices.
+dwiic*		at acpi?		# DesignWare I2C controller
+dwiic*		at pci?			# DesignWare I2C controller
+iic*		at dwiic?
+
+# Thermal monitor and fan controller
+#dbcool* at iic? addr 0x2C		# Unknown other motherboard(s)
+#dbcool* at iic? addr 0x2D		# Tyan S2881
+#dbcool* at iic? addr 0x2E		# Tyan S2882-D
+
+# IBM Thinkpad Active Protection System
+#aps0	at isa? port 0x1600
+
+# Fintek Super I/O with hardware monitor
+#finsio0 	at isa? port 0x4e
+
+# iTE IT87xxF Super I/O with watchdog and sensors support
+#itesio0 	at isa? port 0x2e
+
+# Abit uGuru Hardware system monitor
+#ug0	at isa? port 0xe0
+
+# Serial Presence Detect capable memory modules
+#spdmem* at iic? addr 0x50
+#spdmem* at iic? addr 0x51
+#spdmem* at iic? addr 0x52
+#spdmem* at iic? addr 0x53
+#spdmem* at iic? addr 0x54
+#spdmem* at iic? addr 0x55
+#spdmem* at iic? addr 0x56
+#spdmem* at iic? addr 0x57
+#sdtemp* at iic? addr 0x18
+#sdtemp* at iic? addr 0x19
+#sdtemp* at iic? addr 0x1a
+#sdtemp* at iic? addr 0x1b
+#sdtemp* at iic? addr 0x1c
+#sdtemp* at iic? addr 0x1d
+#sdtemp* at iic? addr 0x1e
+#sdtemp* at iic? addr 0x1f
+
+# Intel GPIO
+igpio*         at acpi? 
+
+# I2C HID devices
+ihidev* at iic?
+
+# I2C Mice
+ims*	at ihidev? reportid ?
+wsmouse* at ims? mux 0
+
+# I2O devices
+iop*	at pci? dev ? function ?	# I/O processor
+iopsp*	at iop? tid ?			# SCSI/FC-AL ports
+ld*	at iop? tid ?			# block devices
+# XXX dpti.c wants a processor type that is not assigned for x86-64
+#dpti*	at iop? tid 0			# DPT/Adaptec control interface
+
+# GPIO devices
+gpio*		at gpiobus?
+
+# 1- Wire support
+#gpioow* 	at gpio? offset ? mask ?	# 1-wire bitbanging via gpio
+gpioow* 	at gpio?
+onewire*	at gpioow?
+
+# 1-Wire devices
+owtemp* 	at onewire?			# Temperature sensors
+
+# I2C support
+#gpioiic*	at gpio?
+#iic*		at gpioiic?
+
+# Keylock support
+#gpiolock*	at gpio?
+
+# Pulsing GPIO pins in software
+#gpiopwm*	at gpio?
+
+# Soekris 6501 GPIO/LED driver (provides gpiobus, needs gpio)
+#soekrisgpio0	at isa? port 0x680
+
+# Nuvoton NCT5104D SuperIO providing GPIO
+nct0		at isa? port ?
+
+# SCSI Controllers and Devices
+
+# PCI SCSI controllers
+adv*	at pci? dev ? function ?	# AdvanSys 1200[A,B], 9xx[U,UA] SCSI
+adw*	at pci? dev ? function ?	# AdvanSys 9x0UW[D], 3940U[2,3]W SCSI
+ahc*	at pci? dev ? function ?	# Adaptec [23]94x, aic78x0 SCSI
+ahd*	at pci? dev ? function ?	# Adaptec aic790x SCSI
+bha*	at pci? dev ? function ?	# BusLogic 9xx SCSI
+dpt*	at pci? dev ? function ?	# DPT SmartCache/SmartRAID
+iha*	at pci? dev ? function ?	# Initio INIC-940/950 SCSI
+isp*	at pci? dev ? function ?	# Qlogic ISP [12]0x0 SCSI/FibreChannel
+mfi*	at pci? dev ? function ?	# LSI MegaRAID SAS
+mfii*	at pci? dev ? function ?	# LSI MegaRAID SAS (Fusion and newer)
+mly*	at pci? dev ? function ?	# Mylex AcceleRAID and eXtremeRAID
+mpt*	at pci? dev ? function ?	# LSILogic 9x9 and 53c1030 (Fusion-MPT)
+mpii*	at pci? dev ? function ?	# LSI Logic Fusion-MPT II
+njs*	at pci? dev ? function ?	# Workbit NinjaSCSI-32
+pcscp*	at pci? dev ? function ?	# AMD 53c974 PCscsi-PCI SCSI
+siop*	at pci? dev ? function ?	# Symbios 53c8xx SCSI
+esiop*	at pci? dev ? function ?	# Symbios 53c875 and newer SCSI
+#options 	SIOP_SYMLED		# drive the act. LED in software
+trm*	at pci? dev ? function ?	# Tekram DC-395U/UW/F, DC-315/U SCSI
+
+# PCMCIA SCSI controllers
+aic*	at pcmcia? function ?		# Adaptec APA-1460 SCSI
+esp*	at pcmcia? function ?		# Qlogic ESP406/FAS408 SCSI
+spc*	at pcmcia? function ?		# Fujitsu MB87030/MB89352 SCSI
+
+# CardBus SCSI cards
+adv*	at cardbus? function ?	# AdvanSys 1200[A,B], 9xx[U,UA] SCSI
+ahc*	at cardbus? function ?	# Adaptec ADP-1480
+njs*	at cardbus? function ?	# Workbit NinjaSCSI-32
+
+# SCSI bus support
+scsibus* at scsi?
+
+# SCSI devices
+sd*	at scsibus? target ? lun ?	# SCSI disk drives
+st*	at scsibus? target ? lun ?	# SCSI tape drives
+cd*	at scsibus? target ? lun ?	# SCSI CD-ROM drives
+ch*	at scsibus? target ? lun ?	# SCSI autochangers
+ses*	at scsibus? target ? lun ?	# SCSI Enclosure Services devices
+ss*	at scsibus? target ? lun ?	# SCSI scanners
+uk*	at scsibus? target ? lun ?	# SCSI unknown
+
+
+# RAID controllers and devices
+aac*	at pci? dev ? function ?	# Adaptec AAC family
+amr*	at pci? dev ? function ?	# AMI/LSI Logic MegaRAID
+arcmsr* at pci? dev ? function ?	# Areca SATA RAID controllers
+cac*	at pci? dev ? function ?	# Compaq PCI array controllers
+ciss*	at pci? dev ? function ?	# HP Smart Array controllers
+icp*	at pci? dev ? function ?	# ICP-Vortex GDT & Intel RAID
+mlx*	at pci? dev ? function ?	# Mylex DAC960 & DEC SWXCR family
+twe*	at pci? dev ? function ?	# 3ware Escalade RAID controllers
+twa*	at pci? dev ? function ?	# 3ware Escalade 9xxx RAID controllers
+
+ld*	at aac? unit ?
+ld*	at amr? unit ?
+ld*	at cac? unit ?
+ld*	at icp? unit ?
+ld*	at twe? unit ?
+ld*	at twa? unit ?
+ld*	at mlx? unit ?
+
+icpsp*	at icp? unit ?			# SCSI pass-through
+
+# IDE and related devices
+# PCI IDE controllers - see pciide(4) for supported hardware.
+# The 0x0001 flag force the driver to use DMA, even if the driver doesn't know
+# how to set up DMA modes for this chip. This may work, or may cause
+# a machine hang with some controllers.
+pciide* at pci? dev ? function ? flags 0x0000	# GENERIC pciide driver
+acardide* at pci? dev ? function ?	# Acard IDE controllers
+aceride* at pci? dev ? function ?	# Acer Lab IDE controllers
+ahcisata* at pci? dev ? function ?	# AHCI SATA controllers
+artsata* at pci? dev ? function ?	# Intel i31244 SATA controller
+cmdide* at pci? dev ? function ?	# CMD tech IDE controllers
+cypide* at pci? dev ? function ?	# Cypress IDE controllers
+hptide* at pci? dev ? function ?	# Triones/HighPoint IDE controllers
+iteide* at pci? dev ? function ?	# IT Express IDE controllers
+ixpide* at pci? dev ? function ?	# ATI IXP IDE controllers
+jmide*	at pci? dev ? function ?	# JMicron PCI-e PATA/SATA controllers
+ahcisata* at jmide?
+mvsata* at pci? dev ? function ?	# Marvell Hercules-I/II
+optiide* at pci? dev ? function ?	# Opti IDE controllers
+piixide* at pci? dev ? function ?	# Intel IDE controllers
+pdcide* at pci? dev ? function ?	# Promise IDE controllers
+pdcsata* at pci? dev ? function ?	# Promise SATA150 controllers
+satalink* at pci? dev ? function ?	# SiI SATALink controllers
+siisata* at pci? dev ? function ?	# SiI SteelVine controllers
+siside* at pci? dev ? function ?	# SiS IDE controllers
+slide*	at pci? dev ? function ?	# Symphony Labs IDE controllers
+svwsata* at pci? dev ? function ?	# ServerWorks SATA controllers
+toshide* at pci? dev ? function ?	# TOSHIBA PICCOLO controllers
+viaide* at pci? dev ? function ?	# VIA/AMD/Nvidia IDE controllers
+
+# PCMCIA IDE controllers
+wdc*	at pcmcia? function ?
+
+# CardBus IDE controllers
+njata*	at cardbus? function ? flags 0x01	# Workbit NinjaATA-32
+siisata* at cardbus? function ? 	# SiI SteelVine controllers
+
+# ISA ST506, ESDI, and IDE controllers
+# Use flags 0x01 if you want to try to use 32bits data I/O (the driver will
+# fall back to 16bits I/O if 32bits I/O are not functional).
+# Some controllers pass the initial 32bit test, but will fail later.
+wdc0	at isa? port 0x1f0 irq 14 flags 0x00
+wdc1	at isa? port 0x170 irq 15 flags 0x00
+
+# ATA (IDE) bus support
+atabus* at ata?
+options 	ATADEBUG
+
+# IDE drives
+# Flags are used only with controllers that support DMA operations
+# and mode settings (e.g. some pciide controllers)
+# The lowest order four bits (rightmost digit) of the flags define the PIO
+# mode to use, the next set of four bits the DMA mode and the third set the
+# UltraDMA mode. For each set of four bits, the 3 lower bits define the mode
+# to use, and the last bit must be 1 for this setting to be used.
+# For DMA and UDMA, 0xf (1111) means 'disable'.
+# 0x0fac means 'use PIO mode 4, DMA mode 2, disable UltraDMA'.
+# (0xc=1100, 0xa=1010, 0xf=1111)
+# 0x0000 means "use whatever the drive claims to support".
+wd*	at atabus? drive ? flags 0x0000
+
+# ATAPI bus support
+atapibus* at atapi?
+
+
+# ATA RAID configuration support, as found on some Promise controllers.
+pseudo-device ataraid
+ld*	at ataraid? vendtype ? unit ?
+
+# ATAPI devices
+# flags have the same meaning as for IDE drives.
+cd*	at atapibus? drive ? flags 0x0000	# ATAPI CD-ROM drives
+sd*	at atapibus? drive ? flags 0x0000	# ATAPI disk drives
+st*	at atapibus? drive ? flags 0x0000	# ATAPI tape drives
+uk*	at atapibus? drive ? flags 0x0000	# ATAPI unknown
+
+
+# NVM Express controllers and devices
+nvme*	at pci? dev ? function ?
+ld*	at nvme? nsid ?
+
+
+# Miscellaneous mass storage devices
+
+# ISA floppy
+#fdc0	at isa? port 0x3f0 irq 6 drq 2	# standard PC floppy controllers
+#fdc1	at isa? port 0x370 irq ? drq ?
+
+# Network Interfaces
+
+# PCI network interfaces
+age*	at pci? dev ? function ?	# Attansic/Atheros L1 Gigabit Ethernet
+alc*	at pci? dev ? function ?	# Attansic/Atheros L1C/L2C Ethernet
+ale*	at pci? dev ? function ?	# Attansic/Atheros L1E Ethernet
+an*	at pci? dev ? function ?	# Aironet PC4500/PC4800 (802.11)
+aq*	at pci? dev ? function ?	# Aquantia AQC 10 gigabit
+ath*	at pci? dev ? function ?	# Atheros 5210/5211/5212 802.11
+athn*	at pci? dev ? function ?	# Atheros AR9k (802.11a/g/n)
+atw*	at pci? dev ? function ?	# ADMtek ADM8211 (802.11)
+bce*	at pci? dev ? function ?	# Broadcom 440x 10/100 Ethernet
+bge*	at pci? dev ? function ?	# Broadcom 570x gigabit Ethernet
+bnx*	at pci? dev ? function ?	# Broadcom NetXtremeII gigabit Ethernet
+bwi*	at pci? dev ? function ?	# Broadcom BCM43xx wireless
+bwfm*	at pci? dev ? function ?	# Broadcom FullMAC
+cas*	at pci? dev ? function ?	# Sun Cassini/Cassini+ Ethernet
+dge*	at pci? dev ? function ?	# Intel 82597 10GbE LR
+ena*	at pci? dev ? function ?	# Amazon.com Elastic Network Adapter
+ep*	at pci? dev ? function ?	# 3Com 3c59x
+epic*	at pci? dev ? function ?	# SMC EPIC/100 Ethernet
+#eqos*	at pci? dev ? function ?	# DesignWare Ethernet QoS
+et*	at pci? dev ? function ?	# Agere/LSI ET1310/ET1301 Gigabit
+ex*	at pci? dev ? function ?	# 3Com 90x[BC]
+fxp*	at pci? dev ? function ?	# Intel EtherExpress PRO 10+/100B
+gem*	at pci? dev ? function ?	# Apple GMAC and Sun ERI gigabit enet
+gsip*	at pci? dev ? function ?	# NS83820 Gigabit Ethernet
+hme*	at pci? dev ? function ?	# Sun Microelectronics STP2002-STQ
+iavf*	at pci? dev ? function ?	# Intel Adaptive Virtual Function
+igc*	at pci? dev ? function ?	# Intel I225 2.5 gigabit
+ipw*	at pci? dev ? function ?	# Intel PRO/Wireless 2100
+iwi*	at pci? dev ? function ?	# Intel PRO/Wireless 2200BG
+iwm*	at pci? dev ? function ?	# Intel Centrino 7260
+iwn*	at pci? dev ? function ?	# Intel PRO/Wireless 4965AGN
+ixg*	at pci? dev ? function ?	# Intel 8259x 10 gigabit
+ixl*	at pci? dev ? function ?	# Intel Ethernet 700 Series
+ixv*	at pci? dev ? function ?	# Intel 8259x 10G virtual function
+jme*	at pci? dev ? function ?	# JMicron JMC2[56]0 ethernet
+kse*	at pci? dev ? function ?	# Micrel KSZ8841/8842 ethernet
+lii*	at pci? dev ? function ?	# Atheros L2 Fast-Ethernet
+malo*	at pci? dev ? function ?	# Marvell Libertas Wireless
+mcx*	at pci? dev ? function ?	# Mellanox 5th generation Ethernet
+mskc*	at pci? dev ? function ?	# Marvell Yukon 2 Gigabit Ethernet
+msk*	at mskc?			# Marvell Yukon 2 Gigabit Ethernet
+mtd*	at pci? dev ? function ?	# Myson MTD803 3-in-1 Ethernet
+ne*	at pci? dev ? function ?	# NE2000-compatible Ethernet
+nfe*	at pci?	dev ? function ?	# NVIDIA nForce Ethernet
+ntwoc*	at pci? dev ? function ?	# Riscom/N2 PCI Sync Serial
+pcn*	at pci? dev ? function ?	# AMD PCnet-PCI Ethernet
+ral*	at pci? dev ? function ?	# Ralink Technology RT25x0 802.11a/b/g
+re*	at pci? dev ? function ?	# Realtek 8139C+/8169/8169S/8110S
+rge*	at pci? dev ? function ?	# Realtek 8125
+rtk*	at pci? dev ? function ?	# Realtek 8129/8139
+rtw*	at pci? dev ? function ?	# Realtek 8180L (802.11)
+rtwn*	at pci? dev ? function ?	# Realtek 8188CE/8192CE 802.11b/g/n
+sf*	at pci? dev ? function ?	# Adaptec AIC-6915 Ethernet
+sip*	at pci? dev ? function ?	# SiS 900/DP83815 Ethernet
+skc*	at pci? dev ? function ?	# SysKonnect SK9821 Gigabit Ethernet
+sk*	at skc?				# SysKonnect SK9821 Gigabit Ethernet
+ste*	at pci? dev ? function ?	# Sundance ST-201 Ethernet
+stge*	at pci? dev ? function ?	# Sundance/Tamarack TC9021 Gigabit
+ti*	at pci? dev ? function ?	# Alteon ACEnic gigabit Ethernet
+tl*	at pci? dev ? function ?	# ThunderLAN-based Ethernet
+tlp*	at pci? dev ? function ?	# DECchip 21x4x and clones
+txp*	at pci? dev ? function ?	# 3com 3cr990
+vge*	at pci? dev ? function ?	# VIATech VT612X Gigabit Ethernet
+vmx*	at pci? dev ? function ?	# VMware VMXNET3
+vr*	at pci? dev ? function ?	# VIA Rhine Fast Ethernet
+wi*	at pci? dev ? function ?	# Intersil Prism Mini-PCI (802.11b)
+wm*	at pci? dev ? function ?	# Intel 82543/82544 gigabit
+wpi*	at pci? dev ? function ?	# Intel PRO/Wireless 3945ABG
+xge*	at pci? dev ? function ?	# Neterion (S2io) Xframe-I 10GbE
+
+# PCMCIA network interfaces
+an*	at pcmcia? function ?		# Aironet PC4500/PC4800 (802.11)
+awi*	at pcmcia? function ?		# BayStack 650/660 (802.11FH/DS)
+cnw*	at pcmcia? function ?		# Xircom/Netwave AirSurfer
+cs*	at pcmcia? function ?		# CS89xx Ethernet
+ep*	at pcmcia? function ?		# 3Com 3c589 and 3c562 Ethernet
+malo*	at pcmcia? function ?		# Marvell Libertas
+mbe*	at pcmcia? function ?		# MB8696x based Ethernet
+ne*	at pcmcia? function ?		# NE2000-compatible Ethernet
+ray*	at pcmcia? function ?		# Raytheon Raylink (802.11)
+sm*	at pcmcia? function ?		# Megahertz Ethernet
+wi*	at pcmcia? function ?		# Lucent/Intersil WaveLan IEEE (802.11)
+xirc*	at pcmcia? function ?		# Xircom CreditCard Ethernet
+com*	at xirc?
+xi*	at xirc?
+
+mhzc*	at pcmcia? function ?		# Megahertz Ethernet/Modem combo cards
+com*	at mhzc?
+sm*	at mhzc?
+
+# CardBus network cards
+ath*	at cardbus? function ?	# Atheros 5210/5211/5212 802.11
+athn*	at cardbus? function ?	# Atheros AR9k (802.11a/g/n) - UNTESTED
+atw*	at cardbus? function ?	# ADMtek ADM8211 (802.11)
+ex*	at cardbus? function ?	# 3Com 3C575TX
+fxp*	at cardbus? function ?	# Intel i8255x
+malo*	at cardbus? function ?	# Marvell Libertas Wireless
+ral*	at cardbus? function ?	# Ralink Technology RT25x0 802.11a/b/g
+re*	at cardbus? function ?	# Realtek 8139C+/8169/8169S/8110S
+rtk*	at cardbus? function ?	# Realtek 8129/8139
+rtw*	at cardbus? function ?	# Realtek 8180L (802.11)
+tlp*	at cardbus? function ?	# DECchip 21143
+
+# MII/PHY support
+acphy*	at mii? phy ?			# DAltima AC101 and AMD Am79c874 PHYs
+amhphy* at mii? phy ?			# AMD 79c901 Ethernet PHYs
+atphy*	at mii?	phy ?			# Attansic/Atheros PHYs
+bmtphy* at mii? phy ?			# Broadcom BCM5201 and BCM5202 PHYs
+brgphy* at mii? phy ?			# Broadcom BCM5400-family PHYs
+ciphy*	at mii? phy ?			# Cicada CS8201 Gig-E PHYs
+dmphy*	at mii? phy ?			# Davicom DM9101 PHYs
+etphy*	at mii? phy ?			# Agere/LSI ET1011 TruePHY Gig-E PHYs
+exphy*	at mii? phy ?			# 3Com internal PHYs
+gentbi* at mii? phy ?			# Generic Ten-Bit 1000BASE-[CLS]X PHYs
+glxtphy* at mii? phy ?			# Level One LXT-1000 PHYs
+gphyter* at mii? phy ?			# NS83861 Gig-E PHY
+icsphy* at mii? phy ?			# Integrated Circuit Systems ICS189x
+igphy*	at mii? phy ?			# Intel IGP01E1000
+ihphy*	at mii? phy ?			# Intel 82577 PHYs
+ikphy*	at mii? phy ?			# Intel 82563 PHYs
+inphy*	at mii? phy ?			# Intel 82555 PHYs
+iophy*	at mii? phy ?			# Intel 82553 PHYs
+ipgphy* at mii? phy ?			# IC PLUS IP1000A/IP1001 PHYs
+jmphy*	at mii? phy ?			# Jmicron JMP202/211 PHYs
+lxtphy* at mii? phy ?			# Level One LXT-970 PHYs
+makphy* at mii? phy ?			# Marvell Semiconductor 88E1000 PHYs
+micphy* at mii? phy ?			# Micrel KSZ[89]xxx PHYs
+nsphy*	at mii? phy ?			# NS83840 PHYs
+nsphyter* at mii? phy ? 		# NS83843 PHYs
+pnaphy* at mii? phy ?			# generic HomePNA PHYs
+qsphy*	at mii? phy ?			# Quality Semiconductor QS6612 PHYs
+rgephy* at mii? phy ?			# Realtek 8169S/8110 internal PHYs
+rlphy*	at mii? phy ?			# Realtek 8139/8201L PHYs
+smscphy* at mii? phy ?			# SMSC LAN87xx PHYs
+sqphy*	at mii? phy ?			# Seeq 80220/80221/80223 PHYs
+tlphy*	at mii? phy ?			# ThunderLAN PHYs
+tqphy*	at mii? phy ?			# TDK Semiconductor PHYs
+ukphy*	at mii? phy ?			# generic unknown PHYs
+urlphy* at mii? phy ?			# Realtek RTL8150L internal PHYs
+
+
+# USB Controller and Devices
+
+# Virtual USB controller
+#pseudo-device	vhci
+
+# PCI USB controllers
+xhci*	at pci?	dev ? function ?	# eXtensible Host Controller
+ehci*	at pci?	dev ? function ?	# Enhanced Host Controller
+ohci*	at pci?	dev ? function ?	# Open Host Controller
+uhci*	at pci?	dev ? function ?	# Universal Host Controller (Intel)
+
+# CardBus USB controllers
+ehci*	at cardbus? function ?	# Enhanced Host Controller
+ohci*	at cardbus? function ?	# Open Host Controller
+uhci*	at cardbus? function ?		# Universal Host Controller (Intel)
+
+# ISA USB controllers
+#slhci0	at isa? port 0x300 irq 5	# ScanLogic SL811HS
+
+# PCMCIA USB controllers
+slhci*	at pcmcia? function ?		# ScanLogic SL811HS
+
+# USB bus support
+#usb*	at vhci?
+usb*	at xhci?
+usb*	at ehci?
+usb*	at ohci?
+usb*	at uhci?
+usb*	at slhci?
+
+include "dev/usb/usbdevices.config"
+
+# PCI IEEE1394 controllers
+fwohci* at pci? dev ? function ?	# IEEE1394 Open Host Controller
+
+# CardBus IEEE1394 controllers
+fwohci* at cardbus? function ?		# IEEE1394 Open Host Controller
+
+ieee1394if* at fwohci?
+fwip*	at ieee1394if?			# IP over IEEE1394
+sbp*	at ieee1394if? euihi ? euilo ?
+
+# Audio Devices
+
+# PCI audio devices
+auacer* at pci? dev ? function ?	# ALi M5455 integrated AC'97 Audio
+auich*	at pci? dev ? function ?	# Intel/AMD/nVidia AC'97 Audio
+auixp*	at pci? dev ? function ?	# ATI IXP AC'97 Audio
+autri*	at pci? dev ? function ?	# Trident 4DWAVE based AC'97 Audio
+auvia*	at pci? dev ? function ?	# VIA AC'97 audio
+clcs*	at pci? dev ? function ?	# Cirrus Logic CS4280
+clct*	at pci? dev ? function ?	# Cirrus Logic CS4281
+cmpci*	at pci? dev ? function ?	# C-Media CMI8338/8738
+eap*	at pci? dev ? function ?	# Ensoniq AudioPCI
+emuxki* at pci? dev ? function ?	# Creative SBLive! and PCI512
+esa*	at pci? dev ? function ?	# ESS Allegro-1 / Maestro-3 PCI Audio
+esm*	at pci? dev ? function ?	# ESS Maestro-1/2/2e PCI Audio Accelerator
+eso*	at pci? dev ? function ?	# ESS Solo-1 PCI AudioDrive
+fms*	at pci? dev ? function ?	# Forte Media FM801
+neo*	at pci? dev ? function ?	# NeoMagic 256 AC'97 Audio
+sv*	at pci? dev ? function ?	# S3 SonicVibes
+yds*	at pci? dev ? function ?	# Yamaha DS-1 PCI Audio
+
+# OPL[23] FM synthesizers
+#opl0	at isa? port 0x388	# use only if not attached to sound card
+opl*	at cmpci? flags 1
+opl*	at eso?
+opl*	at fms?
+opl*	at sv?
+
+# High Definition Audio
+hdaudio*	at pci? dev ? function ?	# High Definition Audio
+hdafg*		at hdaudiobus?
+
+# Audio support
+audio*	at audiobus?
+
+# The spkr driver provides a simple tone interface to the built in speaker.
+spkr*	at pcppi?		# PC speaker
+spkr*	at audio?		# PC speaker (synthesized)
+#wsbell* at spkr?		# Bell for wscons display (module by default)
+
+# MPU 401 UARTs
+#mpu*	at isa? port 0x330 irq 9	# MPU401 or compatible card
+mpu*	at cmpci?
+mpu*	at eso?
+mpu*	at yds?
+
+# MIDI support
+midi*	at midibus?
+midi*	at pcppi?		# MIDI interface to the PC speaker
+
+# FM-Radio devices
+# PCI radio devices
+#gtp*	at pci? dev ? function ? # Guillemot Maxi Radio FM 2000 Radio Card
+
+# Radio support
+#radio*	at gtp?
+
+
+# Video capture devices
+
+coram*	at pci? dev ? function ?	# Conexant CX23885 PCI-E TV
+cxdtv*	at pci? dev ? function ?	# Conexant CX2388[0-3] PCI TV
+
+video*	at videobus?			# Analog capture interface
+dtv*	at dtvbus?			# Digital capture interface
+
+
+# TV cards
+
+# Brooktree 848/849/878/879 based TV cards
+bktr* at pci? dev ? function ?
+radio* at bktr?
+
+
+# Bluetooth Controller and Device support
+
+# Bluetooth PCMCIA Controllers
+bt3c* at pcmcia? function ?		# 3Com 3CRWB6096-A
+btbc* at pcmcia? function ?		# AnyCom BlueCard LSE041/039/139
+
+# Bluetooth SDIO Controllers
+sbt* at sdmmc?
+
+# Bluetooth USB Controllers
+ubt* at uhub? port ?
+aubtfwl* at uhub? port ?
+
+# Bluetooth Device Hub
+bthub* at bcsp?
+bthub* at bt3c?
+bthub* at btbc?
+bthub* at btuart?
+bthub* at sbt?
+bthub* at ubt?
+
+# Bluetooth HID support
+bthidev* at bthub?
+
+# Bluetooth Mouse
+btms* at bthidev? reportid ?
+wsmouse* at btms? mux 0
+
+# Bluetooth Keyboard
+btkbd* at bthidev? reportid ?
+wskbd* at btkbd? console ? mux 1
+
+# Bluetooth Apple Magic Mouse
+btmagic* at bthub?
+wsmouse* at btmagic? mux 0
+
+# Bluetooth Audio support
+btsco* at bthub?
+
+
+# SD/MMC/SDIO Controller and Device support
+
+# SD/MMC controller
+sdhc*	at pci?		# SD Host Controller
+rtsx*	at pci?		# Realtek RTS5209/RTS5229 Card Reader
+sdhc*	at cardbus?	# SD Host Controller
+sdmmc*	at sdhc?	# SD/MMC bus
+sdmmc*	at rtsx?	# SD/MMC bus
+
+ld*	at sdmmc?
+
+
+# Middle Digital, Inc. PCI-Weasel serial console board control
+# devices (watchdog timer, etc.)
+weasel* at pci?
+
+# Virtio devices
+virtio* at pci? dev ? function ?	# Virtio PCI device
+
+include "dev/virtio/virtio.config"
+
+# Hyper-V devices
+vmbus*		at acpi?		# Hyper-V VMBus
+genfb*		at vmbus?		# Hyper-V Synthetic Video Framebuffer
+hvkbd*		at vmbus?		# Hyper-V Synthetic Keyboard
+wskbd*		at hvkbd? console ? mux 1
+hvn*		at vmbus?		# Hyper-V NetVSC
+hvs*		at vmbus?		# Hyper-V StorVSC
+hvheartbeat*	at vmbus?		# Hyper-V Heartbeat Service
+hvshutdown*	at vmbus?		# Hyper-V Guest Shutdown Service
+hvtimesync*	at vmbus?		# Hyper-V Time Synchronization Service
+#hvkvp*		at vmbus?		# Hyper-V Data Exchange Service
+
+# Pseudo-Devices
+
+pseudo-device	crypto			# /dev/crypto device
+pseudo-device	swcrypto		# software crypto implementation
+
+# disk/mass storage pseudo-devices
+pseudo-device	bio			# RAID control device driver
+pseudo-device	ccd			# concatenated/striped disk devices
+pseudo-device	cgd			# cryptographic disk devices
+pseudo-device	raid			# RAIDframe disk driver
+options 	RAID_AUTOCONFIG		# auto-configuration of RAID components
+# Options to enable various other RAIDframe RAID types.
+#options 	RF_INCLUDE_EVENODD=1
+#options 	RF_INCLUDE_RAID5_RS=1
+#options 	RF_INCLUDE_PARITYLOGGING=1
+#options 	RF_INCLUDE_CHAINDECLUSTER=1
+#options 	RF_INCLUDE_INTERDECLUSTER=1
+#options 	RF_INCLUDE_PARITY_DECLUSTERING=1
+#options 	RF_INCLUDE_PARITY_DECLUSTERING_DS=1
+pseudo-device	fss			# file system snapshot device
+
+pseudo-device	md			# memory disk device (ramdisk)
+options 	MEMORY_DISK_HOOKS	# enable md specific hooks
+options 	MEMORY_DISK_DYNAMIC	# enable dynamic resizing
+
+pseudo-device	vnd			# disk-like interface to files
+options 	VND_COMPRESSION		# compressed vnd(4)
+
+
+# network pseudo-devices
+pseudo-device	bpfilter		# Berkeley packet filter
+pseudo-device	carp			# Common Address Redundancy Protocol
+pseudo-device	loop			# network loopback
+#pseudo-device	mpls			# MPLS pseudo-interface
+pseudo-device	ppp			# Point-to-Point Protocol
+pseudo-device	pppoe			# PPP over Ethernet (RFC 2516)
+pseudo-device	sl			# Serial Line IP
+pseudo-device	irframetty		# IrDA frame line discipline
+pseudo-device	tun			# network tunneling over tty
+pseudo-device	tap			# virtual Ethernet
+pseudo-device	gre			# generic L3 over IP tunnel
+pseudo-device	gif			# IPv[46] over IPv[46] tunnel (RFC1933)
+pseudo-device	ipsecif			# tunnel interface for routing based ipsec
+#pseudo-device	faith			# IPv[46] tcp relay translation i/f
+pseudo-device	stf			# 6to4 IPv6 over IPv4 encapsulation
+pseudo-device	vlan			# IEEE 802.1q encapsulation
+pseudo-device	bridge			# simple inter-network bridging
+pseudo-device	vether			# Virtual Ethernet for bridge
+pseudo-device	agr			# IEEE 802.3ad link aggregation
+pseudo-device	l2tp			# L2TPv3 interface
+pseudo-device	lagg			# Link aggregation interface
+pseudo-device	npf			# NPF packet filter
+
+#pseudo-device	canloop			# CAN loopback interface
+
+#
+# accept filters
+pseudo-device	accf_data		# "dataready" accept filter
+pseudo-device	accf_http		# "httpready" accept filter
+
+# miscellaneous pseudo-devices
+pseudo-device	pty			# pseudo-terminals
+pseudo-device	sequencer		# MIDI sequencer
+# rnd works; RND_COM does not on port i386 yet.
+#options 	RND_COM			# use "com" randomness as well (BROKEN)
+pseudo-device	clockctl		# user control of clock subsystem
+pseudo-device	ksyms			# /dev/ksyms
+pseudo-device	lockstat		# lock profiling
+pseudo-device	bcsp			# BlueCore Serial Protocol
+pseudo-device	btuart			# Bluetooth HCI UART (H4)
+#pseudo-device	nvmm			# NetBSD Virtual Machine Monitor
+pseudo-device 	swwdog			# software watchdog timer -- swwdog(4)
+
+# wscons pseudo-devices
+pseudo-device	wsmux			# mouse & keyboard multiplexor
+pseudo-device	wsfont
+# Give us a choice of fonts based on monitor size
+options 	FONT_BOLD8x16
+options 	FONT_BOLD16x32
+
+# pseudo audio device driver
+pseudo-device	pad
+
+# userland interface to drivers, including autoconf and properties retrieval
+pseudo-device	drvctl
+
+# EFI runtime support
+options 	EFI_RUNTIME
+pseudo-device 	efi			# /dev/efi
+
+include "dev/veriexec.config"
+
+options 	PAX_SEGVGUARD=0		# PaX Segmentation fault guard
+options 	PAX_MPROTECT=1		# PaX mprotect(2) restrictions
+options 	PAX_MPROTECT_DEBUG=1	# PaX mprotect debug
+options 	PAX_ASLR=1		# PaX Address Space Layout Randomization
+options 	PAX_ASLR_DEBUG=1	# PaX ASLR debug
+
+# Pull in optional local configuration - always at end
+cinclude	"arch/amd64/conf/GENERIC.local"

--- a/sys/compat/common/kern_info_09.c
+++ b/sys/compat/common/kern_info_09.c
@@ -55,6 +55,8 @@ __KERNEL_RCSID(0, "$NetBSD: kern_info_09.c,v 1.22 2021/09/07 11:43:02 riastradh 
 
 #include <compat/common/compat_mod.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 static struct syscall_package kern_info_09_syscalls[] = {
 	{ SYS_compat_09_ogetdomainname, 0,
 	    (sy_call_t *)compat_09_sys_getdomainname },
@@ -122,7 +124,7 @@ compat_09_sys_uname(struct lwp *l,
 
 	memset(&outsname, 0, sizeof(outsname));
 	strncpy(outsname.sysname, ostype, sizeof(outsname.sysname));
-	strncpy(outsname.nodename, hostname, sizeof(outsname.nodename));
+	strncpy(outsname.nodename, new_ns.hostname, sizeof(outsname.nodename));
 	strncpy(outsname.release, osrelease, sizeof(outsname.release));
 	dp = outsname.version;
 	ep = &outsname.version[sizeof(outsname.version) - 1];

--- a/sys/compat/common/kern_info_43.c
+++ b/sys/compat/common/kern_info_43.c
@@ -67,6 +67,8 @@ __KERNEL_RCSID(0, "$NetBSD: kern_info_43.c,v 1.40 2021/09/07 11:43:02 riastradh 
 
 #include <compat/common/compat_mod.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 static struct syscall_package kern_info_43_syscalls[] = {
 	{ SYS_compat_43_ogetdtablesize, 0,
 	    (sy_call_t *)compat_43_sys_getdtablesize },
@@ -98,7 +100,7 @@ int
 compat_43_sys_gethostid(struct lwp *l, const void *v, register_t *retval)
 {
 
-	*(int32_t *)retval = hostid;
+	*(int32_t *)retval = new_ns.hostid;
 	return (0);
 }
 
@@ -258,7 +260,7 @@ compat_43_sys_getkerninfo(struct lwp *l, const struct compat_43_sys_getkerninfo_
 				size = sizeof(ksi) +
 				    strlen(ostype) + strlen(cpu_model) +
 				    strlen(osrelease) + strlen(machine) +
-				    strlen(version) + strlen(hostname) + 6;
+				    strlen(version) + strlen(new_ns.hostname) + 6;
 				error = 0;
 				break;
 			}
@@ -295,7 +297,13 @@ compat_43_sys_getkerninfo(struct lwp *l, const struct compat_43_sys_getkerninfo_
 
 			getmicroboottime(&tv);
 			timeval_to_timeval50(&tv, &ksi.boottime);
-			COPY(hostname);
+			// TODO: make ifdef
+			// char* hostname_str = new_ns.hostname;
+			// COPY(hostname_str);
+			ksi.hostname = us - (u_long) usi;
+			if ((error = copyoutstr(new_ns.hostname, us, 1024, &len)) != 0)
+			    return error;
+			us += len;
 
 			size = (us - (char *) &usi[1]) + sizeof(ksi);
 

--- a/sys/compat/linux/common/linux_misc.c
+++ b/sys/compat/linux/common/linux_misc.c
@@ -125,6 +125,8 @@ __KERNEL_RCSID(0, "$NetBSD: linux_misc.c,v 1.267 2024/10/01 16:41:29 riastradh E
 
 #include <compat/linux/linux_syscallargs.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 const int linux_ptrace_request_map[] = {
 	LINUX_PTRACE_TRACEME,	PT_TRACE_ME,
 	LINUX_PTRACE_PEEKTEXT,	PT_READ_I,
@@ -440,11 +442,11 @@ linux_sys_uname(struct lwp *l, const struct linux_sys_uname_args *uap, register_
 
 	memset(&luts, 0, sizeof(luts));
 	strlcpy(luts.l_sysname, linux_sysname, sizeof(luts.l_sysname));
-	strlcpy(luts.l_nodename, hostname, sizeof(luts.l_nodename));
+	strlcpy(luts.l_nodename, new_ns.hostname, sizeof(luts.l_nodename));
 	strlcpy(luts.l_release, linux_release, sizeof(luts.l_release));
 	strlcpy(luts.l_version, linux_version, sizeof(luts.l_version));
 	strlcpy(luts.l_machine, LINUX_UNAME_ARCH, sizeof(luts.l_machine));
-	strlcpy(luts.l_domainname, domainname, sizeof(luts.l_domainname));
+	strlcpy(luts.l_domainname, new_ns.domainname, sizeof(luts.l_domainname));
 
 	return copyout(&luts, SCARG(uap, up), sizeof(luts));
 }

--- a/sys/compat/linux32/common/linux32_utsname.c
+++ b/sys/compat/linux32/common/linux32_utsname.c
@@ -72,6 +72,8 @@ __KERNEL_RCSID(0, "$NetBSD: linux32_utsname.c,v 1.10 2019/08/23 06:47:58 maxv Ex
 #include <compat/linux32/common/linux32_socketcall.h>
 #include <compat/linux32/linux32_syscallargs.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 int
 linux32_sys_uname(struct lwp *l, const struct linux32_sys_uname_args *uap, register_t *retval)
 {
@@ -83,11 +85,11 @@ linux32_sys_uname(struct lwp *l, const struct linux32_sys_uname_args *uap, regis
 
 	memset(&luts, 0, sizeof(luts));
 	strlcpy(luts.l_sysname, linux32_sysname, sizeof(luts.l_sysname));
-	strlcpy(luts.l_nodename, hostname, sizeof(luts.l_nodename));
+	strlcpy(luts.l_nodename, new_ns.hostname, sizeof(luts.l_nodename));
 	strlcpy(luts.l_release, linux32_release, sizeof(luts.l_release));
 	strlcpy(luts.l_version, linux32_version, sizeof(luts.l_version));
 	strlcpy(luts.l_machine, LINUX_UNAME_ARCH, sizeof(luts.l_machine));
-	strlcpy(luts.l_domainname, domainname, sizeof(luts.l_domainname));
+	strlcpy(luts.l_domainname, new_ns.domainname, sizeof(luts.l_domainname));
        
 	lp = SCARG_P32(uap, up);
 
@@ -104,7 +106,7 @@ linux32_sys_olduname(struct lwp *l, const struct linux32_sys_olduname_args *uap,
 
 	memset(&luts, 0, sizeof(luts));
 	strlcpy(luts.l_sysname, linux32_sysname, sizeof(luts.l_sysname));
-	strlcpy(luts.l_nodename, hostname, sizeof(luts.l_nodename));
+	strlcpy(luts.l_nodename, new_ns.hostname, sizeof(luts.l_nodename));
 	strlcpy(luts.l_release, linux32_release, sizeof(luts.l_release));
 	strlcpy(luts.l_version, linux32_version, sizeof(luts.l_version));
 	strlcpy(luts.l_machine, LINUX_UNAME_ARCH, sizeof(luts.l_machine));
@@ -122,7 +124,7 @@ linux32_sys_oldolduname(struct lwp *l, const struct linux32_sys_oldolduname_args
  
 	memset(&luts, 0, sizeof(luts));
         strlcpy(luts.l_sysname, linux32_sysname, sizeof(luts.l_sysname));
-        strlcpy(luts.l_nodename, hostname, sizeof(luts.l_nodename));
+        strlcpy(luts.l_nodename, new_ns.hostname, sizeof(luts.l_nodename));
         strlcpy(luts.l_release, linux32_release, sizeof(luts.l_release));
         strlcpy(luts.l_version, linux32_version, sizeof(luts.l_version));
         strlcpy(luts.l_machine, LINUX_UNAME_ARCH, sizeof(luts.l_machine));

--- a/sys/conf/files
+++ b/sys/conf/files
@@ -42,6 +42,7 @@ defflag opt_pool.h		POOL_QUARANTINE
 defflag opt_pool.h		POOL_NOCACHE
 defflag				FAULT
 
+defflag opt_ns.h		NS
 defparam opt_copy_symtab.h	makeoptions_COPY_SYMTAB
 
 defparam			DEFCORENAME
@@ -290,7 +291,6 @@ include "net/files.pf"
 obsolete defflag		CCITT		# obsolete
 obsolete defflag		HDLC		# obsolete
 obsolete defflag		LLC		# obsolete
-obsolete defflag opt_ns.h	NS NSIP		# obsolete
 obsolete defflag		IPX		# obsolete
 obsolete defparam opt_md.h	MEMORY_RBFLAGS	# superseded by
 						# MEMORY_DISK_RBFLAGS

--- a/sys/conf/files
+++ b/sys/conf/files
@@ -43,6 +43,7 @@ defflag opt_pool.h		POOL_NOCACHE
 defflag				FAULT
 
 defflag opt_ns.h		NS
+
 defparam opt_copy_symtab.h	makeoptions_COPY_SYMTAB
 
 defparam			DEFCORENAME
@@ -291,6 +292,7 @@ include "net/files.pf"
 obsolete defflag		CCITT		# obsolete
 obsolete defflag		HDLC		# obsolete
 obsolete defflag		LLC		# obsolete
+obsolete defflag		NSIP		# obsolete
 obsolete defflag		IPX		# obsolete
 obsolete defparam opt_md.h	MEMORY_RBFLAGS	# superseded by
 						# MEMORY_DISK_RBFLAGS

--- a/sys/dev/ieee1394/firewire.c
+++ b/sys/dev/ieee1394/firewire.c
@@ -61,6 +61,8 @@ __KERNEL_RCSID(0, "$NetBSD: firewire.c,v 1.55 2022/05/22 11:27:35 andvar Exp $")
 
 #include "locators.h"
 
+#include <sys/uts.h> // TODO: make ifdef
+
 struct crom_src_buf {
 	struct crom_src	src;
 	struct crom_chunk root;
@@ -1454,7 +1456,7 @@ fw_reset_crom(struct firewire_comm *fc)
 	crom_add_entry(root, CSRKEY_VENDOR, CSRVAL_VENDOR_PRIVATE);
 	crom_add_simple_text(src, root, &buf->vendor, PROJECT_STR);
 	crom_add_entry(root, CSRKEY_HW, __NetBSD_Version__);
-	crom_add_simple_text(src, root, &buf->hw, hostname);
+	crom_add_simple_text(src, root, &buf->hw, new_ns.hostname);
 }
 
 /*

--- a/sys/dev/vmt/vmt_subr.c
+++ b/sys/dev/vmt/vmt_subr.c
@@ -48,6 +48,8 @@
 #include <dev/vmt/vmtreg.h>
 #include <dev/vmt/vmtvar.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 /* #define VMT_DEBUG */
 
 static int vmt_sysctl_setup_root(device_t);
@@ -133,7 +135,8 @@ struct vmt_tclo_rpc {
 	{ NULL, NULL },
 };
 
-extern char hostname[MAXHOSTNAMELEN];
+//extern char hostname[MAXHOSTNAMELEN];
+extern struct uts_ns new_ns;
 
 static void
 vmt_probe_cmd(struct vm_backdoor *frame, uint16_t cmd)
@@ -423,8 +426,8 @@ vmt_update_guest_uptime(struct vmt_softc *sc)
 static void
 vmt_update_guest_info(struct vmt_softc *sc)
 {
-	if (strncmp(sc->sc_hostname, hostname, sizeof(sc->sc_hostname)) != 0) {
-		strlcpy(sc->sc_hostname, hostname, sizeof(sc->sc_hostname));
+	if (strncmp(sc->sc_hostname, new_ns.hostname, sizeof(sc->sc_hostname)) != 0) {
+		strlcpy(sc->sc_hostname, new_ns.hostname, sizeof(sc->sc_hostname));
 		if (vm_rpc_send_rpci_tx(sc, "SetGuestInfo  %d %s",
 		    VM_GUEST_INFO_DNS_NAME, sc->sc_hostname) != 0) {
 			device_printf(sc->sc_dev, "unable to set hostname\n");

--- a/sys/fs/cd9660/cd9660_rrip.c
+++ b/sys/fs/cd9660/cd9660_rrip.c
@@ -58,6 +58,8 @@ __KERNEL_RCSID(0, "$NetBSD: cd9660_rrip.c,v 1.18 2015/03/28 19:24:05 maxv Exp $"
 #include <fs/cd9660/cd9660_rrip.h>
 #include <fs/cd9660/iso_rrip.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 typedef struct {
 	char type[2];
 	int (*func)(void *, ISO_RRIP_ANALYZE *);
@@ -176,8 +178,8 @@ cd9660_rrip_slink(void *v, ISO_RRIP_ANALYZE *ana)
 
 		case ISO_SUSP_CFLAG_HOST:
 			/* Inserting hostname i.e. "kurt.tools.de" */
-			inbuf = hostname;
-			wlen = hostnamelen;
+			inbuf = new_ns.hostname;
+			wlen = new_ns.hostnamelen;
 			break;
 
 		case ISO_SUSP_CFLAG_CONTINUE:
@@ -246,8 +248,8 @@ cd9660_rrip_altname(void *v, ISO_RRIP_ANALYZE *ana)
 
 	case ISO_SUSP_CFLAG_HOST:
 		/* Inserting hostname i.e. "kurt.tools.de" */
-		inbuf = hostname;
-		wlen = hostnamelen;
+		inbuf = new_ns.hostname;
+		wlen = new_ns.hostnamelen;
 		break;
 
 	case ISO_SUSP_CFLAG_CONTINUE:

--- a/sys/kern/files.kern
+++ b/sys/kern/files.kern
@@ -171,7 +171,7 @@ file	kern/sys_memfd.c		kern
 file	kern/sys_module.c		kern
 file	kern/sys_mqueue.c		mqueue
 file	kern/sys_lwp.c			kern
-file	kern/sys_ns.c 			ns
+#file	kern/sys_ns.c 			ns
 file	kern/sys_pipe.c			!pipe_socketpair
 file	kern/sys_process.c		ptrace_hooks | ktrace
 file	kern/sys_process_lwpstatus.c	kern

--- a/sys/kern/files.kern
+++ b/sys/kern/files.kern
@@ -171,6 +171,7 @@ file	kern/sys_memfd.c		kern
 file	kern/sys_module.c		kern
 file	kern/sys_mqueue.c		mqueue
 file	kern/sys_lwp.c			kern
+file	kern/sys_ns.c 			ns
 file	kern/sys_pipe.c			!pipe_socketpair
 file	kern/sys_process.c		ptrace_hooks | ktrace
 file	kern/sys_process_lwpstatus.c	kern

--- a/sys/kern/init_sysctl.c
+++ b/sys/kern/init_sysctl.c
@@ -68,6 +68,8 @@ __KERNEL_RCSID(0, "$NetBSD: init_sysctl.c,v 1.228 2023/09/09 16:01:09 christos E
 #include <sys/unistd.h>
 #include <sys/vnode_impl.h>     /* For vfs_drainvnodes(). */
 
+#include <sys/uts.h> // TODO: make ifdef
+
 int security_setidcore_dump;
 char security_setidcore_path[MAXPATHLEN] = "/var/crash/%n.core";
 uid_t security_setidcore_owner = 0;
@@ -894,14 +896,14 @@ sysctl_kern_hostid(SYSCTLFN_ARGS)
 	int error, inthostid;
 	struct sysctlnode node;
 
-	inthostid = hostid;  /* XXX assumes sizeof int <= sizeof long */
+	inthostid = new_ns.hostid;  /* XXX assumes sizeof int <= sizeof long */
 	node = *rnode;
 	node.sysctl_data = &inthostid;
 	error = sysctl_lookup(SYSCTLFN_CALL(&node));
 	if (error || newp == NULL)
 		return (error);
 
-	hostid = (unsigned)inthostid;
+	new_ns.hostid = (unsigned)inthostid;
 
 	return (0);
 }

--- a/sys/kern/init_sysctl_base.c
+++ b/sys/kern/init_sysctl_base.c
@@ -40,7 +40,13 @@ __KERNEL_RCSID(0, "$NetBSD: init_sysctl_base.c,v 1.9 2023/12/20 20:35:37 andvar 
 #include <sys/kernel.h>
 #include <sys/disklabel.h>
 
+#ifdef _KERNEL_OPT
+#include "opt_ns.h"
+#endif
+
+#ifdef NS
 #include <sys/uts.h> // TODO: make ifdef
+#endif
 
 static int sysctl_setlen(SYSCTLFN_PROTO);
 
@@ -281,6 +287,12 @@ static int
 sysctl_setlen(SYSCTLFN_ARGS)
 {
 	int error;
+
+#ifdef NS
+    printf("NS: enabled, new_ns at %p\n", &new_ns);
+#else
+    printf("NS: No NS enabled\n");
+#endif
 
 	error = sysctl_lookup(SYSCTLFN_CALL(rnode));
 	if (error || newp == NULL)

--- a/sys/kern/init_sysctl_base.c
+++ b/sys/kern/init_sysctl_base.c
@@ -40,6 +40,8 @@ __KERNEL_RCSID(0, "$NetBSD: init_sysctl_base.c,v 1.9 2023/12/20 20:35:37 andvar 
 #include <sys/kernel.h>
 #include <sys/disklabel.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 static int sysctl_setlen(SYSCTLFN_PROTO);
 
 /*
@@ -164,17 +166,18 @@ SYSCTL_SETUP(sysctl_kernbase_setup, "sysctl kern subtree base setup")
 		       SYSCTL_DESCR("Kernel version"),
 		       NULL, 0, __UNCONST(&version), 0,
 		       CTL_KERN, KERN_VERSION, CTL_EOL);
+// TODO: make ifdef for NOT using namespaces
 	sysctl_createv(clog, 0, NULL, NULL,
 		       CTLFLAG_PERMANENT|CTLFLAG_READWRITE,
 		       CTLTYPE_STRING, "hostname",
 		       SYSCTL_DESCR("System hostname"),
-		       sysctl_setlen, 0, hostname, MAXHOSTNAMELEN,
+		       sysctl_setlen, 0, new_ns.hostname, MAXHOSTNAMELEN,
 		       CTL_KERN, KERN_HOSTNAME, CTL_EOL);
 	sysctl_createv(clog, 0, NULL, NULL,
 		       CTLFLAG_PERMANENT|CTLFLAG_READWRITE,
 		       CTLTYPE_STRING, "domainname",
 		       SYSCTL_DESCR("YP domain name"),
-		       sysctl_setlen, 0, domainname, MAXHOSTNAMELEN,
+		       sysctl_setlen, 0, new_ns.domainname, MAXHOSTNAMELEN,
 		       CTL_KERN, KERN_DOMAINNAME, CTL_EOL);
 	sysctl_createv(clog, 0, NULL, NULL,
 		       CTLFLAG_PERMANENT|CTLFLAG_IMMEDIATE,
@@ -285,10 +288,10 @@ sysctl_setlen(SYSCTLFN_ARGS)
 
 	switch (rnode->sysctl_num) {
 	case KERN_HOSTNAME:
-		hostnamelen = strlen((const char*)rnode->sysctl_data);
+		new_ns.hostnamelen = strlen((const char*)rnode->sysctl_data);
 		break;
 	case KERN_DOMAINNAME:
-		domainnamelen = strlen((const char*)rnode->sysctl_data);
+		new_ns.domainnamelen = strlen((const char*)rnode->sysctl_data);
 		break;
 	}
 

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -96,6 +96,8 @@ __KERNEL_RCSID(0, "$NetBSD: kern_sysctl.c,v 1.271 2024/09/08 09:36:51 rillig Exp
 
 #include <crypto/blake2/blake2s.h>
 
+#include <sys/uts.h> // TODO: Add through config
+
 #define	MAXDESCLEN	1024
 MALLOC_DEFINE(M_SYSCTLNODE, "sysctlnode", "sysctl node structures");
 MALLOC_DEFINE(M_SYSCTLDATA, "sysctldata", "misc sysctl data");
@@ -163,6 +165,8 @@ char domainname[MAXHOSTNAMELEN];
 int domainnamelen;
 
 long hostid;
+
+struct uts_ns new_ns;
 
 #ifndef DEFCORENAME
 #define	DEFCORENAME	"%n.core"

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -74,6 +74,7 @@ __KERNEL_RCSID(0, "$NetBSD: kern_sysctl.c,v 1.271 2024/09/08 09:36:51 rillig Exp
 
 #ifdef _KERNEL_OPT
 #include "opt_defcorename.h"
+#include "opt_ns.h"
 #endif
 
 #include "ksyms.h"
@@ -95,10 +96,6 @@ __KERNEL_RCSID(0, "$NetBSD: kern_sysctl.c,v 1.271 2024/09/08 09:36:51 rillig Exp
 #include <sys/systm.h>
 
 #include <crypto/blake2/blake2s.h>
-
-
-#include "opt_ns.h"
-
 
 #define	MAXDESCLEN	1024
 MALLOC_DEFINE(M_SYSCTLNODE, "sysctlnode", "sysctl node structures");
@@ -161,6 +158,7 @@ kmutex_t sysctl_file_marker_lock;
  * Attributes stored in the kernel.
  */
 #ifdef NS
+#include <sys/uts.h>
 struct uts_ns new_ns = {
 	.hostnamelen = 0,
 	.domainnamelen = 0,

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -158,6 +158,15 @@ kmutex_t sysctl_file_marker_lock;
 /*
  * Attributes stored in the kernel.
  */
+#ifdef _SYS_UTS_NS_H_
+#error BOOM! USING CUSTOM UTS
+struct uts_ns new_ns = {
+	.hostnamelen = 0,
+	.domainnamelen = 0,
+	.hostid = 0,
+};
+#else
+#error WHAT?? STILL USING OLD UTS
 char hostname[MAXHOSTNAMELEN];
 int hostnamelen;
 
@@ -165,8 +174,7 @@ char domainname[MAXHOSTNAMELEN];
 int domainnamelen;
 
 long hostid;
-
-struct uts_ns new_ns;
+#endif /* _SYS_UTS_NS_H_ */
 
 #ifndef DEFCORENAME
 #define	DEFCORENAME	"%n.core"

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -96,7 +96,9 @@ __KERNEL_RCSID(0, "$NetBSD: kern_sysctl.c,v 1.271 2024/09/08 09:36:51 rillig Exp
 
 #include <crypto/blake2/blake2s.h>
 
-#include <sys/uts.h> // TODO: Add through config
+
+#include "opt_ns.h"
+
 
 #define	MAXDESCLEN	1024
 MALLOC_DEFINE(M_SYSCTLNODE, "sysctlnode", "sysctl node structures");
@@ -158,15 +160,16 @@ kmutex_t sysctl_file_marker_lock;
 /*
  * Attributes stored in the kernel.
  */
-#ifdef _SYS_UTS_NS_H_
-#error BOOM! USING CUSTOM UTS
+#ifdef NS
 struct uts_ns new_ns = {
 	.hostnamelen = 0,
 	.domainnamelen = 0,
 	.hostid = 0,
 };
 #else
-#error WHAT?? STILL USING OLD UTS
+#endif /* NS */
+
+// TODO: make else once ready
 char hostname[MAXHOSTNAMELEN];
 int hostnamelen;
 
@@ -174,7 +177,6 @@ char domainname[MAXHOSTNAMELEN];
 int domainnamelen;
 
 long hostid;
-#endif /* _SYS_UTS_NS_H_ */
 
 #ifndef DEFCORENAME
 #define	DEFCORENAME	"%n.core"

--- a/sys/kern/sys_ns.c
+++ b/sys/kern/sys_ns.c
@@ -1,0 +1,199 @@
+/*	$NetBSD$	*/
+
+
+
+
+
+/*-Add commentMore actions
+
+
+ * Copyright (c) 2025 The NetBSD Foundation, Inc.
+
+
+ * All rights reserved.
+
+
+ *
+
+
+ * This code is derived from software contributed to The NetBSD Foundation
+
+
+ * by Christoph Badura.
+
+
+ *
+
+
+ * Redistribution and use in source and binary forms, with or without
+
+
+ * modification, are permitted provided that the following conditions
+
+
+ * are met:
+
+
+ * 1. Redistributions of source code must retain the above copyright
+
+
+ *    notice, this list of conditions and the following disclaimer.
+
+
+ * 2. Redistributions in binary form must reproduce the above copyright
+
+
+ *    notice, this list of conditions and the following disclaimer in the
+
+
+ *    documentation and/or other materials provided with the distribution.
+
+
+ *
+
+
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+
+
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+
+
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+
+
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+
+
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+
+
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+
+
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+
+
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+
+
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+
+
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+
+
+ * POSSIBILITY OF SUCH DAMAGE.
+
+
+ */
+
+
+
+
+
+/*
+
+
+ * Linux compatible namespaces: system calls.
+
+
+ */
+
+
+
+#include <sys/uts.h>
+
+
+#include <sys/cdefs.h>
+
+
+__KERNEL_RCSID(0, "$NetBSD$");
+
+
+
+
+
+#ifdef _KERNEL_OPT
+
+
+#include "opt_ns.h"
+
+
+#endif
+
+
+
+
+
+#include <sys/types.h>
+
+
+#include <sys/param.h>
+
+
+
+
+
+#include <sys/sched.h>
+
+
+#include <sys/syscallargs.h>
+
+
+
+
+
+/* Note that retval is unused as this syscall only returns success/failure. */
+
+
+int
+
+
+sys_unshare(struct lwp *l, const struct sys_unshare_args *uap,
+
+
+    register_t *retval)
+
+
+{
+
+
+	/* {
+
+
+		syscallarg(int) 	flags;
+
+
+	} */
+
+
+	int flags = SCARG(uap, flags);
+
+
+	int error;
+
+
+
+
+
+	/* Validate the flags.  */
+
+
+	/* XXX Sync with Linux: CLONE_FILES|CLONE_FS|CLONE_SYSVSEM|
+
+
+	 *     CLONE_THREAD|CLONE_SIGHAND|CLONE_VM|CLONE_NEWTIME
+
+
+	 */
+
+
+	if (flags & ~CLONE_NSMASK) {
+		/* Unknown flags.  */
+		return EINVAL;
+	}
+
+	error = EINVAL;		/* For now, always fail. */
+
+	return error;
+}

--- a/sys/kern/vfs_lookup.c
+++ b/sys/kern/vfs_lookup.c
@@ -65,6 +65,8 @@ __KERNEL_RCSID(0, "$NetBSD: vfs_lookup.c,v 1.238 2024/12/07 02:27:38 riastradh E
 #include <sys/vnode.h>
 #include <sys/vnode_impl.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 #ifndef MAGICLINKS
 #define MAGICLINKS 0
 #endif
@@ -146,7 +148,7 @@ symlink_magic(struct proc *p, char *cp, size_t *len)
 			slen = VNL(MACHINE);
 			SUBSTITUTE("machine", MACHINE, slen);
 		} else if (MATCH("hostname")) {
-			SUBSTITUTE("hostname", hostname, hostnamelen);
+			SUBSTITUTE("hostname", new_ns.hostname, new_ns.hostnamelen);
 		} else if (MATCH("osrelease")) {
 			slen = strlen(osrelease);
 			SUBSTITUTE("osrelease", osrelease, slen);
@@ -157,7 +159,7 @@ symlink_magic(struct proc *p, char *cp, size_t *len)
 			slen = strlen(kernel_ident);
 			SUBSTITUTE("kernel_ident", kernel_ident, slen);
 		} else if (MATCH("domainname")) {
-			SUBSTITUTE("domainname", domainname, domainnamelen);
+			SUBSTITUTE("domainname", new_ns.domainname, new_ns.domainnamelen);
 		} else if (MATCH("ostype")) {
 			slen = strlen(ostype);
 			SUBSTITUTE("ostype", ostype, slen);

--- a/sys/miscfs/kernfs/kernfs_vnops.c
+++ b/sys/miscfs/kernfs/kernfs_vnops.c
@@ -63,6 +63,8 @@ __KERNEL_RCSID(0, "$NetBSD: kernfs_vnops.c,v 1.174 2022/03/27 17:10:56 christos 
 
 #include <uvm/uvm_extern.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 #define KSTRING	256		/* Largest I/O available via this filesystem */
 #define	UIO_MX 32
 
@@ -427,8 +429,8 @@ kernfs_xread(struct kernfs_node *kfs, int off, char **bufp, size_t len, size_t *
 	}
 
 	case KFShostname: {
-		char *cp = hostname;
-		size_t xlen = hostnamelen;
+		char *cp = new_ns.hostname;
+		size_t xlen = new_ns.hostnamelen;
 
 		if (xlen >= (len - 2))
 			return (EINVAL);
@@ -471,9 +473,9 @@ kernfs_xwrite(const struct kernfs_node *kfs, char *bf, size_t len)
 	case KFShostname:
 		if (bf[len-1] == '\n')
 			--len;
-		memcpy(hostname, bf, len);
-		hostname[len] = '\0';
-		hostnamelen = (size_t) len;
+		memcpy(new_ns.hostname, bf, len);
+		new_ns.hostname[len] = '\0';
+		new_ns.hostnamelen = (size_t) len;
 		return (0);
 
 	default:

--- a/sys/net80211/ieee80211_ioctl.c
+++ b/sys/net80211/ieee80211_ioctl.c
@@ -76,6 +76,8 @@ __KERNEL_RCSID(0, "$NetBSD: ieee80211_ioctl.c,v 1.69 2021/09/21 15:00:34 christo
 
 #include <compat/sys/sockio.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 #ifdef __FreeBSD__
 #define	IS_UP(_ic) \
 	(((_ic)->ic_ifp->if_flags & IFF_UP) &&			\
@@ -221,10 +223,10 @@ ieee80211_cfgget(struct ieee80211com *ic, u_long cmd, void *data)
 		/* nothing appropriate */
 		break;
 	case WI_RID_NODENAME:
-		strlcpy((char *)&wreq->wi_val[1], hostname,
+		strlcpy((char *)&wreq->wi_val[1], new_ns.hostname,
 		    sizeof(wreq->wi_val) - sizeof(wreq->wi_val[0]));
-		wreq->wi_val[0] = htole16(strlen(hostname));
-		wreq->wi_len = (1 + strlen(hostname) + 1) / 2;
+		wreq->wi_val[0] = htole16(strlen(new_ns.hostname));
+		wreq->wi_len = (1 + strlen(new_ns.hostname) + 1) / 2;
 		break;
 	case WI_RID_CURRENT_SSID:
 		if (ic->ic_state != IEEE80211_S_RUN) {

--- a/sys/netinet6/icmp6.c
+++ b/sys/netinet6/icmp6.c
@@ -105,6 +105,8 @@ __KERNEL_RCSID(0, "$NetBSD: icmp6.c,v 1.258 2024/07/05 04:31:54 rin Exp $");
 #include <netinet6/nd6.h>
 #include <netinet6/scope6_var.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 #ifdef IPSEC
 #include <netipsec/ipsec.h>
 #include <netipsec/ipsec6.h>
@@ -787,8 +789,8 @@ _icmp6_input(struct mbuf *m, int off, int proto)
 				m_free(n);
 				break;
 			}
-			if (maxhlen > hostnamelen)
-				maxhlen = hostnamelen;
+			if (maxhlen > new_ns.hostnamelen)
+				maxhlen = new_ns.hostnamelen;
 			/*
 			 * Copy IPv6 and ICMPv6 only.
 			 */
@@ -799,7 +801,7 @@ _icmp6_input(struct mbuf *m, int off, int proto)
 
 			p = (u_char *)(nicmp6 + 1);
 			memset(p, 0, 4);
-			memcpy(p + 4, hostname, maxhlen); /* meaningless TTL */
+			memcpy(p + 4, new_ns.hostname, maxhlen); /* meaningless TTL */
 
 			m_copy_pkthdr(n, m);
 			n->m_pkthdr.len = n->m_len = sizeof(struct ip6_hdr) +
@@ -1355,7 +1357,7 @@ ni6_input(struct mbuf *m, int off)
 			 *   wildcard match, if gethostname(3) side has
 			 *   truncated hostname.
 			 */
-			n = ni6_nametodns(hostname, hostnamelen, 0);
+			n = ni6_nametodns(new_ns.hostname, new_ns.hostnamelen, 0);
 			if (!n || n->m_next || n->m_len == 0)
 				goto bad;
 			IP6_EXTHDR_GET(subj, char *, m,
@@ -1479,7 +1481,7 @@ ni6_input(struct mbuf *m, int off)
 		/*
 		 * XXX do we really have FQDN in variable "hostname"?
 		 */
-		n->m_next = ni6_nametodns(hostname, hostnamelen, oldfqdn);
+		n->m_next = ni6_nametodns(new_ns.hostname, new_ns.hostnamelen, oldfqdn);
 		if (n->m_next == NULL)
 			goto bad;
 		/* XXX we assume that n->m_next is not a chain */

--- a/sys/netinet6/in6.c
+++ b/sys/netinet6/in6.c
@@ -108,6 +108,8 @@ __KERNEL_RCSID(0, "$NetBSD: in6.c,v 1.292 2024/03/01 23:50:27 riastradh Exp $");
 #include <compat/netinet6/in6_var.h>
 #include <compat/netinet6/nd6.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 MALLOC_DEFINE(M_IP6OPT, "ip6_options", "IPv6 options");
 
 /* enable backward compatibility code for obsoleted ioctls */
@@ -956,7 +958,7 @@ in6_join_mcastgroups(struct in6_aliasreq *ifra, struct in6_ifaddr *ia,
 		 */
 		dad_delay = cprng_fast32() % (MAX_RTR_SOLICITATION_DELAY * hz);
 	}
-	if (in6_nigroup(ifp, hostname, hostnamelen, &mltaddr) != 0)
+	if (in6_nigroup(ifp, new_ns.hostname, new_ns.hostnamelen, &mltaddr) != 0)
 		;
 	else if ((imm = in6_joingroup(ifp, &mltaddr.sin6_addr, &error,
 		  dad_delay)) == NULL) { /* XXX jinmei */

--- a/sys/netinet6/in6_ifattach.c
+++ b/sys/netinet6/in6_ifattach.c
@@ -59,6 +59,8 @@ __KERNEL_RCSID(0, "$NetBSD: in6_ifattach.c,v 1.122 2024/04/11 07:34:37 knakahara
 #include <netinet6/ip6_mroute.h>
 #include <netinet6/scope6_var.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 int ip6_auto_linklocal = 1;	/* enable by default */
 
 #if 0
@@ -137,14 +139,14 @@ get_rand_ifid(struct in6_addr *in6)	/* upper 64bits are preserved */
 
 #if 0
 	/* we need at least several letters as seed for ifid */
-	if (hostnamelen < 3)
+	if (new_uts.hostnamelen < 3)
 		return -1;
 #endif
 
 	/* generate 8 bytes of pseudo-random value. */
 	memset(&ctxt, 0, sizeof(ctxt));
 	MD5Init(&ctxt);
-	MD5Update(&ctxt, (u_char *)hostname, hostnamelen);
+	MD5Update(&ctxt, (u_char *)new_ns.hostname, new_ns.hostnamelen);
 	MD5Final(digest, &ctxt);
 
 	/* assumes sizeof(digest) > sizeof(ifid) */

--- a/sys/nfs/nfs_bootdhcp.c
+++ b/sys/nfs/nfs_bootdhcp.c
@@ -80,6 +80,8 @@ __KERNEL_RCSID(0, "$NetBSD: nfs_bootdhcp.c,v 1.60 2024/10/20 14:01:52 mlelstv Ex
 #include <nfs/nfsmount.h>
 #include <nfs/nfsdiskless.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 /*
  * There are two implementations of NFS diskless boot.
  * This implementation uses BOOTP (RFC951, RFC1048), and
@@ -754,18 +756,18 @@ bootp_extract(struct bootp *bootp, int replylen,
 			memcpy(&gateway, p, 4);
 			break;
 		    case TAG_HOST_NAME:
-			if (len >= sizeof(hostname)) {
+			if (len >= sizeof(new_ns.hostname)) {
 				printf("nfs_boot: host name >= %lu bytes\n",
-				       (u_long)sizeof(hostname));
+				       (u_long)sizeof(new_ns.hostname));
 				break;
 			}
 			myname = p;
 			mynamelen = len;
 			break;
 		    case TAG_DOMAIN_NAME:
-			if (len >= sizeof(domainname)) {
+			if (len >= sizeof(new_ns.domainname)) {
 				printf("nfs_boot: domain name >= %lu bytes\n",
-				       (u_long)sizeof(domainname));
+				       (u_long)sizeof(new_ns.domainname));
 				break;
 			}
 			mydomain = p;
@@ -820,15 +822,15 @@ bootp_extract(struct bootp *bootp, int replylen,
 	 */
 	if (myname) {
 		myname[mynamelen] = '\0';
-		strncpy(hostname, myname, sizeof(hostname));
-		hostnamelen = mynamelen;
-		printf("nfs_boot: my_name=%s\n", hostname);
+		strncpy(new_ns.hostname, myname, sizeof(new_ns.hostname));
+		new_ns.hostnamelen = mynamelen;
+		printf("nfs_boot: my_name=%s\n", new_ns.hostname);
 	}
 	if (mydomain) {
 		mydomain[mydomainlen] = '\0';
-		strncpy(domainname, mydomain, sizeof(domainname));
-		domainnamelen = mydomainlen;
-		printf("nfs_boot: my_domain=%s\n", domainname);
+		strncpy(new_ns.domainname, mydomain, sizeof(new_ns.domainname));
+		new_ns.domainnamelen = mydomainlen;
+		printf("nfs_boot: my_domain=%s\n", new_ns.domainname);
 	}
 	if (!(*flags & NFS_BOOT_HAS_MYIP)) {
 		nd->nd_myip = bootp->bp_yiaddr;

--- a/sys/nfs/nfs_bootparam.c
+++ b/sys/nfs/nfs_bootparam.c
@@ -71,6 +71,8 @@ __KERNEL_RCSID(0, "$NetBSD: nfs_bootparam.c,v 1.40 2024/07/05 04:31:54 rin Exp $
 #include <nfs/nfsdiskless.h>
 #include <nfs/nfs_var.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 /*
  * There are two implementations of NFS diskless boot.
  * This implementation uses Sun RPC/bootparams, and the
@@ -181,7 +183,7 @@ nfs_bootparam(struct nfs_diskless *nd, struct lwp *lwp, int *flags)
 	}
 	*flags |= NFS_BOOT_HAS_SERVADDR | NFS_BOOT_HAS_SERVER;
 	printf("nfs_boot: server_addr=%s\n", inet_ntoa(sin->sin_addr));
-	printf("nfs_boot: hostname=%s\n", hostname);
+	printf("nfs_boot: hostname=%s\n", new_ns.hostname);
 
 	/*
 	 * Now fetch the server:pathname strings and server IP
@@ -359,14 +361,14 @@ bp_whoami(struct sockaddr_in *bpsin, struct in_addr *my_ip,
 	bpsin->sin_addr.s_addr = sin->sin_addr.s_addr;
 
 	/* client name */
-	hostnamelen = MAXHOSTNAMELEN-1;
-	m = xdr_string_decode(m, hostname, &hostnamelen);
+	new_ns.hostnamelen = MAXHOSTNAMELEN-1;
+	m = xdr_string_decode(m, new_ns.hostname, &new_ns.hostnamelen);
 	if (m == NULL)
 		goto bad;
 
 	/* domain name */
-	domainnamelen = MAXHOSTNAMELEN-1;
-	m = xdr_string_decode(m, domainname, &domainnamelen);
+	new_ns.domainnamelen = MAXHOSTNAMELEN-1;
+	m = xdr_string_decode(m, new_ns.domainname, &new_ns.domainnamelen);
 	if (m == NULL)
 		goto bad;
 
@@ -412,7 +414,7 @@ bp_getfile(struct sockaddr_in *bpsin, const char *key,
 	 */
 
 	/* client name (hostname) */
-	m  = xdr_string_encode(hostname, hostnamelen);
+	m  = xdr_string_encode(new_ns.hostname, new_ns.hostnamelen);
 	if (m == NULL)
 		return (ENOMEM);
 

--- a/sys/rump/librump/rumpkern/rump.c
+++ b/sys/rump/librump/rumpkern/rump.c
@@ -90,6 +90,8 @@ __KERNEL_RCSID(0, "$NetBSD: rump.c,v 1.361 2023/10/05 19:41:07 ad Exp $");
 #include <uvm/uvm_extern.h>
 #include <uvm/uvm_readahead.h>
 
+#include <sys/uts.h> // TODO: make ifdef
+
 char machine[] = MACHINE;
 char machine_arch[] = MACHINE_ARCH;
 
@@ -455,12 +457,12 @@ rump_init_callback(void (*cpuinit_callback) (void))
 	module_init_class(MODULE_CLASS_ANY);
 
 	if (rumpuser_getparam(RUMPUSER_PARAM_HOSTNAME,
-	    hostname, MAXHOSTNAMELEN) != 0) {
+	    new_ns.hostname, MAXHOSTNAMELEN) != 0) {
 		panic(
 		    "%s: mandatory hypervisor configuration (HOSTNAME) missing",
 		    __func__);
 	}
-	hostnamelen = strlen(hostname);
+	new_ns.hostnamelen = strlen(new_ns.hostname);
 
 	sigemptyset(&sigcantmask);
 

--- a/sys/sys/kernel.h
+++ b/sys/sys/kernel.h
@@ -44,11 +44,15 @@
 
 /* Global variables for the kernel. */
 
+#ifdef _SYS_UTS_NS_H_
 extern long hostid;
 extern char hostname[MAXHOSTNAMELEN];
 extern int hostnamelen;
 extern char domainname[MAXHOSTNAMELEN];
 extern int domainnamelen;
+#else
+extern struct uts_ns new_ns;
+#endif /* _SYS_UTS_NS_H_ */
 
 extern int rtc_offset;		/* offset of rtc from UTC in minutes */
 

--- a/sys/sys/uts.h
+++ b/sys/sys/uts.h
@@ -1,0 +1,19 @@
+#ifndef _SYS_UTS_NS_H_
+#define _SYS_UTS_NS_H_
+
+#ifdef _KERNEL
+// I've seen this in sys/sys/rnd.h, do we need it? why?
+
+#include <sys/param.h>
+
+struct uts_ns {
+	char hostname[MAXHOSTNAMELEN];
+	int hostnamelen;
+	char domainname[MAXHOSTNAMELEN];
+	int domainnamelen;
+	long hostid;
+};
+
+#endif /* _KERNEL */
+
+#endif /* !_SYS_UTS_NS_H_ */


### PR DESCRIPTION
We intend to modify NetBSD to stop using variables related to UTS, like "char hostname[MAXHOSTNAMELEN]", and instead encapsulate them in a uts_namespace struct which allows us to more easily isolate UTS across (future) namespaces.